### PR TITLE
CSS fixes

### DIFF
--- a/src/Dashboard/Pages/Home.razor
+++ b/src/Dashboard/Pages/Home.razor
@@ -7,9 +7,8 @@
     <form>
         <div class="g-3 row row-cols-6">
             <div class="input-group col">
-                <label class="input-group-text col-auto col-xl-1" for="repository">
-                    Repository &nbsp;
-                    <Icon Name="@(Icons.Code)" />
+                <label class="input-group-text col-auto" for="repository" title="Repository" aria-label="Repository">
+                    <Icon Name="@(Icons.Code)" FixedWidth="true" />
                 </label>
                 <select class="form-select" id="repository" name="repo" disabled="@(DisableRepositories)" @onchange="RepositoryChangedAsync">
                     @if (GitHubService.Repositories.Count < 1)
@@ -27,9 +26,8 @@
                 </select>
             </div>
             <div class="input-group col">
-                <label class="input-group-text col-auto col-xl-1" for="branch">
-                    Branch &nbsp;
-                    <Icon Name="@(Icons.CodeBranch)" />
+                <label class="input-group-text col-auto" for="branch" title="Branch" aria-label="Branch">
+                    <Icon Name="@(Icons.CodeBranch)" FixedWidth="true" />
                 </label>
                 <select class="form-select" id="branch" name="branch" disabled="@(DisableBranches)" @onchange="BranchChangedAsync">
                     @if (GitHubService.Branches.Count < 1)

--- a/src/Dashboard/wwwroot/app.css
+++ b/src/Dashboard/wwwroot/app.css
@@ -49,12 +49,14 @@ img.user-profile {
   margin-right: 4px;
 }
 
-a.header-content {
-  display: inline-grid;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  width: 55vw;
+@media (max-width: 576px) {
+  a.header-content {
+    display: inline-grid;
+    max-width: 55vw;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 }
 
 .benchmark-set {


### PR DESCRIPTION
- Fix confusing link behaviour on desktop by only applying the workaround to truncate the repo link width on mobile.
- Align two select add-ons by removing the text and using fixed-width icons.
