### PR TITLE
Fixes for GitHub Pages

### DIFF
--- a/Dashboard.ruleset
+++ b/Dashboard.ruleset
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="Benchmarks Rules" Description="This rule set contains rules for the Benchmarks solution." ToolsVersion="17.0">
+<RuleSet Name="Dashboard Rules" Description="This rule set contains rules for the Dashboard solution." ToolsVersion="17.0">
   <IncludeAll Action="Warning" />
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
     <Rule Id="CA1014" Action="None" />

--- a/src/Dashboard/Routes.cs
+++ b/src/Dashboard/Routes.cs
@@ -11,10 +11,10 @@ public static class Routes
     /// <summary>
     /// Gets the URL of the home page.
     /// </summary>
-    public static string Home { get; } = "/";
+    public static string Home { get; } = string.Empty;
 
     /// <summary>
     /// Gets the URL of the token page.
     /// </summary>
-    public static string Token { get; } = "/token";
+    public static string Token { get; } = "token";
 }

--- a/src/Dashboard/wwwroot/404.html
+++ b/src/Dashboard/wwwroot/404.html
@@ -92,7 +92,7 @@
 <body id="app">
   <nav class="navbar navbar-expand-lg fixed-top navbar-dark bg-primary">
     <div class="container-fluid">
-      <a id="link-home" href="/" class="navbar-brand">
+      <a id="link-home" href="" class="navbar-brand">
         benchmarks.martincostello.com
         <span class="fa-solid fa-rocket d-lg-inline" aria-hidden="true"></span>
       </a>

--- a/src/Dashboard/wwwroot/404.html
+++ b/src/Dashboard/wwwroot/404.html
@@ -2,6 +2,14 @@
 <html lang="en-gb">
 <head prefix="og:http://ogp.me/ns#">
   <base href="/" />
+  <!--
+  <script>
+    if (window.location.pathname.length > 1) {
+      const base = document.querySelector('base');
+      base.href = window.location.pathname;
+    }
+  </script>
+  -->
   <title>Benchmarks - benchmarks.martincostello.com</title>
   <meta http-equiv="cache-control" content="no-cache, no-store" />
   <meta http-equiv="content-type" content="text/html; charset=utf-8" />

--- a/src/Dashboard/wwwroot/index.html
+++ b/src/Dashboard/wwwroot/index.html
@@ -92,7 +92,7 @@
 <body id="app">
   <nav class="navbar navbar-expand-lg fixed-top navbar-dark bg-primary">
     <div class="container-fluid">
-      <a id="link-home" href="/" class="navbar-brand">
+      <a id="link-home" href="" class="navbar-brand">
         benchmarks.martincostello.com
         <span class="fa-solid fa-rocket d-lg-inline" aria-hidden="true"></span>
       </a>

--- a/src/Dashboard/wwwroot/index.html
+++ b/src/Dashboard/wwwroot/index.html
@@ -2,6 +2,14 @@
 <html lang="en-gb">
 <head prefix="og:http://ogp.me/ns#">
   <base href="/" />
+  <!--
+  <script>
+    if (window.location.pathname.length > 1) {
+      const base = document.querySelector('base');
+      base.href = window.location.pathname;
+    }
+  </script>
+  -->
   <title>Benchmarks - benchmarks.martincostello.com</title>
   <meta http-equiv="cache-control" content="no-cache, no-store" />
   <meta http-equiv="content-type" content="text/html; charset=utf-8" />


### PR DESCRIPTION
- Fix relative URLs to account for GitHub Pages without custom domains.
- Add commented out code to dynamically set the `href` value of `<base>` so that relative URLs work correctly in GitHub Pages without a custom domain.
