### PR TITLE
More CSS fixes

### DIFF
--- a/src/Dashboard/Layout/MainLayout.razor
+++ b/src/Dashboard/Layout/MainLayout.razor
@@ -15,29 +15,35 @@
     string instance = Options.Value.GitHubInstance;
 }
 <footer>
-    <p>
-        &copy; @(author) @(DateTime.UtcNow.Year) |
-        Powered by <a rel="noopener" href="https://github.com/martincostello/benchmarkdotnet-results-publisher">benchmarkdotnet-results-publisher</a>
-        and @(System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription) |
-        Built from
-        <a href="@(commit)" title="View commit @(GitMetadata.Commit) on @(instance)" target="_blank" rel="noopener">
-            <code>@(GitMetadata.Commit[..7])</code>
-        </a>
-        on
-        <a href="@(branch)" title="View branch @(GitMetadata.Branch) on on @(instance)" target="_blank" rel="noopener">
-            <code>@(GitMetadata.Branch)</code>
-        </a>
-        @if (!string.IsNullOrWhiteSpace(GitMetadata.BuildId))
-        {
-            <text>
-                by
-                <a href="@(build)" title="View deployment on on @(instance)" target="_blank" rel="noopener">
-                    GitHub
-                </a>
-            </text>
-        }
-        <span class="ps-1" title="@(GitMetadata.Timestamp.ToString("u", CultureInfo.InvariantCulture))">@(GitMetadata.Timestamp.Humanize())</span>.
-    </p>
+    <div class="pb-3 row row-cols-auto justify-content-left">
+        <div class="col">
+            &copy; @(author) @(DateTime.UtcNow.Year)
+        </div>
+        <div class="col d-none d-lg-block">
+            Powered by <a rel="noopener" href="https://github.com/martincostello/benchmarkdotnet-results-publisher">benchmarkdotnet-results-publisher</a>
+            and @(System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription)
+        </div>
+        <div class="col d-none d-lg-block">
+            Built from
+            <a href="@(commit)" title="View commit @(GitMetadata.Commit) on @(instance)" target="_blank" rel="noopener">
+                <code>@(GitMetadata.Commit[..7])</code>
+            </a>
+            on
+            <a href="@(branch)" title="View branch @(GitMetadata.Branch) on on @(instance)" target="_blank" rel="noopener">
+                <code>@(GitMetadata.Branch)</code>
+            </a>
+            @if (!string.IsNullOrWhiteSpace(GitMetadata.BuildId))
+            {
+                <text>
+                    by
+                    <a href="@(build)" title="View deployment on on @(instance)" target="_blank" rel="noopener">
+                        GitHub
+                    </a>
+                </text>
+            }
+            <span class="ps-1" title="@(GitMetadata.Timestamp.ToString("u", CultureInfo.InvariantCulture))">@(GitMetadata.Timestamp.Humanize())</span>
+        </div>
+    </div>
 </footer>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.min.js" integrity="sha512-CQBWl4fJHWbryGE+Pc7UAxWMUMNMWzWxF4SQo9CgkJIN1kx6djDQZjh3Y8SZ1d+6I+1zze6Z7kHXO7q3UyZAWw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 

--- a/src/Dashboard/Layout/Navbar.razor
+++ b/src/Dashboard/Layout/Navbar.razor
@@ -10,7 +10,7 @@
             @(options.BrandName)
             @foreach (var iconClasses in options.BrandIcons)
             {
-                <span class="@(iconClasses) d-lg-inline mx-1" aria-hidden="true"></span>
+                <span class="@(iconClasses) d-lg-inline ms-1" aria-hidden="true"></span>
             }
         </a>
         <button class="navbar-toggler"

--- a/src/Dashboard/wwwroot/app.css
+++ b/src/Dashboard/wwwroot/app.css
@@ -24,6 +24,17 @@ header {
   margin-right: 1em;
 }
 
+@media (min-width: 576px) {
+  footer > div.row > div.col:not(:first-child) {
+    padding-left: 0rem;
+  }
+
+  footer > div.row > div.col:not(:last-child):after {
+    padding-left: calc(0.5 * var(--bs-body-font-size));
+    content: '|';
+  }
+}
+
 img.user-profile {
   max-height: 1.25em;
   max-width: 1.25em;

--- a/src/Dashboard/wwwroot/app.css
+++ b/src/Dashboard/wwwroot/app.css
@@ -30,8 +30,8 @@ header {
   }
 
   footer > div.row > div.col:not(:last-child):after {
-    padding-left: calc(0.5 * var(--bs-body-font-size));
     content: '|';
+    padding-left: calc(0.5 * var(--bs-body-font-size));
   }
 }
 
@@ -48,16 +48,12 @@ img.user-profile {
   word-break: unset;
 }
 
-.form-control {
-  color: #596364;
-}
-
 .no-resize {
   resize: none;
 }
 
 .header-label {
-  margin-right: 4px;
+  margin-right: 0.25em;
 }
 
 @media (max-width: 576px) {
@@ -71,7 +67,7 @@ img.user-profile {
 }
 
 .benchmark-set {
-  margin: 8px 0;
+  margin: 0.5em 0;
   width: 100%;
   display: flex;
   flex-direction: column;
@@ -101,10 +97,6 @@ img.user-profile {
   max-width: 1000px;
 }
 
-.github-name::before {
-  content: attr(data-github-type);
-}
-
 #blazor-error-ui {
   background: lightyellow;
   bottom: 0;
@@ -132,7 +124,7 @@ img.user-profile {
 }
 
 .blazor-error-boundary::after {
-    content: "An error has occurred."
+    content: "Something went wrong."
 }
 
 .loading-progress-text {
@@ -160,19 +152,15 @@ img.user-profile {
 }
 
 /* Custom CSS different from just vanilla Bootstrap 5 */
-a {
-  color: #0F7661;
-}
-
 .btn-github {
-  background-color: #000;
-  border-color: #000;
-  color: #fff;
-  text-decoration-color: #fff;
+  background-color: black;
+  border-color: white;
+  color: white;
+  text-decoration-color: white;
 }
 
 .btn-github:hover {
-  background-color: #424649;
-  border-color: #373b3e;
-  color: #fff;
+  background-color: color-mix(in srgb, black 80%, transparent);
+  border-color: color-mix(in srgb, black, transparent);;
+  color: white;
 }

--- a/src/Dashboard/wwwroot/appsettings.json
+++ b/src/Dashboard/wwwroot/appsettings.json
@@ -7,7 +7,7 @@
     }
   },
   "Dashboard": {
-    "BrandName": "benchmarks.martincostello.com",
+    "BrandName": ".NET Benchmarks",
     "BrandIcons": [ "fa-solid fa-rocket" ],
     "DataSetColors": {
       "Memory": "#e34c26",


### PR DESCRIPTION
- Just add padding to the start of the icon, not both sides.
- Shorten the brand name so that it's not too long on mobile and makes the menu render weirdly.
- Improve the rendering of the footer so that long links aren't shown on mobile.
- Remove unused CSS rules.
- Use `rem` instead of pixel values.
- Change error text.
- Use named colours.
