### PR TITLE
Avoid bounce after load

### DIFF
--- a/src/Dashboard/wwwroot/404.html
+++ b/src/Dashboard/wwwroot/404.html
@@ -94,7 +94,7 @@
     <div class="container-fluid">
       <a id="link-home" href="" class="navbar-brand">
         benchmarks.martincostello.com
-        <span class="fa-solid fa-rocket d-lg-inline" aria-hidden="true"></span>
+        <span class="fa-solid fa-rocket d-lg-inline ms-1" aria-hidden="true"></span>
       </a>
     </div>
   </nav>

--- a/src/Dashboard/wwwroot/index.html
+++ b/src/Dashboard/wwwroot/index.html
@@ -94,7 +94,7 @@
     <div class="container-fluid">
       <a id="link-home" href="" class="navbar-brand">
         benchmarks.martincostello.com
-        <span class="fa-solid fa-rocket d-lg-inline" aria-hidden="true"></span>
+        <span class="fa-solid fa-rocket d-lg-inline ms-1" aria-hidden="true"></span>
       </a>
     </div>
   </nav>


### PR DESCRIPTION
Add missing margin so that the icon doesn't bounce after Blazor loads.
