### PR TITLE
Refactor token storage

### DIFF
--- a/src/Dashboard/GitHubClient.cs
+++ b/src/Dashboard/GitHubClient.cs
@@ -4,7 +4,6 @@
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json.Serialization.Metadata;
-using Blazored.LocalStorage;
 using MartinCostello.Benchmarks.Models;
 using Microsoft.Extensions.Options;
 
@@ -15,7 +14,7 @@ namespace MartinCostello.Benchmarks;
 /// </summary>
 public sealed class GitHubClient(
     HttpClient client,
-    ILocalStorageService localStorage,
+    GitHubTokenStore tokenStore,
     IOptions<DashboardOptions> options)
 {
     /// <summary>
@@ -121,15 +120,12 @@ public sealed class GitHubClient(
             cancellationToken);
     }
 
-    private async Task<string?> GetTokenAsync(CancellationToken cancellationToken)
-        => await localStorage.GetItemAsStringAsync("github-token", cancellationToken);
-
     private async Task SetHeadersAsync(HttpRequestHeaders headers, CancellationToken cancellationToken)
     {
         headers.Add("Accept", "application/vnd.github+json");
         headers.Add("X-GitHub-Api-Version", options.Value.GitHubApiVersion);
 
-        var token = await GetTokenAsync(cancellationToken);
+        var token = await tokenStore.GetTokenAsync(cancellationToken);
 
         if (!string.IsNullOrEmpty(token))
         {

--- a/src/Dashboard/GitHubTokenStore.cs
+++ b/src/Dashboard/GitHubTokenStore.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using Blazored.LocalStorage;
+using Microsoft.Extensions.Options;
+
+namespace MartinCostello.Benchmarks;
+
+/// <summary>
+/// A class representing a store for GitHub authentication tokens. This class cannot be inherited.
+/// </summary>
+public sealed class GitHubTokenStore(
+    ILocalStorageService localStorage,
+    ISyncLocalStorageService syncLocalStorage,
+    IOptions<DashboardOptions> options)
+{
+    private string Key => $"github-token-{options.Value.GitHubServerUrl.Host}";
+
+    /// <summary>
+    /// Gets the GitHub token, if any, from local storage.
+    /// </summary>
+    /// <returns>
+    /// The GitHub token in local storage, otherwise <see langword="null"/>.
+    /// </returns>
+    public string? GetToken()
+        => syncLocalStorage.GetItemAsString(Key);
+
+    /// <summary>
+    /// Gets the GitHub token, if any, from local storage as an asynchronous operation.
+    /// </summary>
+    /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> to use.</param>
+    /// <returns>
+    /// A <see cref="Task"/> representing the asynchronous operation to get the
+    /// GitHub token in local storage, otherwise <see langword="null"/>.
+    /// </returns>
+    public async Task<string?> GetTokenAsync(CancellationToken cancellationToken = default)
+        => await localStorage.GetItemAsStringAsync(Key, cancellationToken);
+
+    /// <summary>
+    /// Stores the specified GitHub token in local storage as an asynchronous operation.
+    /// </summary>
+    /// <param name="token">The GitHub token.</param>
+    /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> to use.</param>
+    /// <returns>
+    /// A <see cref="Task"/> representing the asynchronous operation to store the token.
+    /// </returns>
+    public async Task StoreTokenAsync(string token, CancellationToken cancellationToken = default)
+        => await localStorage.SetItemAsStringAsync(Key, token, cancellationToken);
+}

--- a/src/Dashboard/Layout/Navbar.razor
+++ b/src/Dashboard/Layout/Navbar.razor
@@ -79,7 +79,7 @@
                                 id="sign-out"
                                 title="Sign out"
                                 type="button"
-                                @onclick="SignOut">
+                                @onclick="SignOutAsync">
                             Sign out
                             <Icon Name="@(Icons.RightFromBracket)" />
                         </button>
@@ -136,9 +136,9 @@
     private void OnUserChanged(object? sender, GitHubUserChangedEventArgs args)
         => StateHasChanged();
 
-    private void SignOut()
+    private async Task SignOutAsync()
     {
-        GitHubService.SignOut();
+        await GitHubService.SignOutAsync();
 
         var uri = Options.Value.IsGitHubEnterprise ? Routes.Token : Routes.Home;
         Navigation.NavigateTo(uri);

--- a/src/Dashboard/Program.cs
+++ b/src/Dashboard/Program.cs
@@ -21,6 +21,7 @@ builder.Services.AddBlazoredLocalStorage();
 
 builder.Services.AddScoped<GitHubClient>();
 builder.Services.AddScoped<GitHubService>();
+builder.Services.AddScoped<GitHubTokenStore>();
 
 await builder.Build().RunAsync();
 

--- a/src/Dashboard/_Imports.razor
+++ b/src/Dashboard/_Imports.razor
@@ -14,6 +14,5 @@
 @using MartinCostello.Benchmarks.Models
 
 @inject GitHubService GitHubService
-@inject Blazored.LocalStorage.ISyncLocalStorageService LocalStorage
 @inject NavigationManager Navigation
 @inject IOptions<DashboardOptions> Options


### PR DESCRIPTION
- Add dedicated class for getting and setting the GitHub token.
- Shard the GitHub token in local storage by GitHub server host.

This started as an idea to redesign the `/token` page to work with [GitHub OAuth Device flow](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#device-flow), but I discovered far too late that that doesn't support CORS, so can't be used from a SPA application.

The code for as far as I got with that is here: https://github.com/martincostello/benchmarks-dashboard/commit/2f8276171d0334e5810a9d01bf4204774d40fcc1

Maybe one day it'll work, or I'll proxy it through another back-end I have.
