### PR TITLE
Use GitHub device flow to acquire token

### DIFF
--- a/src/Dashboard/AppJsonSerializerContext.cs
+++ b/src/Dashboard/AppJsonSerializerContext.cs
@@ -10,6 +10,8 @@ namespace MartinCostello.Benchmarks;
 [ExcludeFromCodeCoverage]
 [JsonSerializable(typeof(BenchmarkResults))]
 [JsonSerializable(typeof(IList<GitHubBranch>))]
+[JsonSerializable(typeof(GitHubAccessToken))]
+[JsonSerializable(typeof(GitHubDeviceCode))]
 [JsonSerializable(typeof(GitHubRepository))]
 [JsonSerializable(typeof(GitHubUser))]
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, WriteIndented = true)]

--- a/src/Dashboard/Components/Icon.razor
+++ b/src/Dashboard/Components/Icon.razor
@@ -16,6 +16,11 @@
         classes.Add($"text-{Color}");
     }
 
+    if (Spin)
+    {
+        classes.Add("fa-spin");
+    }
+
     string classList = string.Join(' ', classes);
 }
 
@@ -39,6 +44,12 @@
     /// </summary>
     [Parameter]
     public bool FixedWidth { get; init; }
+
+    /// <summary>
+    /// Gets whether the icon should spin.
+    /// </summary>
+    [Parameter]
+    public bool Spin { get; init; }
 
     /// <summary>
     /// Gets whether the icon is stacked.

--- a/src/Dashboard/Components/Spinner.razor
+++ b/src/Dashboard/Components/Spinner.razor
@@ -18,7 +18,7 @@
 
     string classList = string.Join(' ', classes);
 }
-<div class="@(classList)" id="@(Id)" role="status">
+<div class="@(classList)" id="@(Id)" role="status" title="@(LoadingText)">
     <span class="visually-hidden">@(LoadingText)</span>
 </div>
 

--- a/src/Dashboard/DashboardOptions.cs
+++ b/src/Dashboard/DashboardOptions.cs
@@ -39,6 +39,11 @@ public sealed class DashboardOptions
     public string GitHubApiVersion { get; set; } = "2022-11-28";
 
     /// <summary>
+    /// Gets or sets the GitHub client ID to use to authenticate using the device flow.
+    /// </summary>
+    public string GitHubClientId { get; set; } = string.Empty;
+
+    /// <summary>
     /// Gets or sets the URI to use for the GitHub data.
     /// </summary>
     public Uri GitHubDataUrl { get; set; } = new("https://raw.githubusercontent.com");
@@ -47,6 +52,11 @@ public sealed class DashboardOptions
     /// Gets or sets the URI to use for the GitHub server.
     /// </summary>
     public Uri GitHubServerUrl { get; set; } = new("https://github.com");
+
+    /// <summary>
+    /// Gets or sets the URI to use for acquiring GitHub tokens.
+    /// </summary>
+    public Uri GitHubTokenUrl { get; set; } = new("https://api.martincostello.com/github/");
 
     /// <summary>
     /// Gets or sets the owner of the dashboard repository.

--- a/src/Dashboard/GitHubDeviceTokenService.cs
+++ b/src/Dashboard/GitHubDeviceTokenService.cs
@@ -1,0 +1,91 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using MartinCostello.Benchmarks.Models;
+
+namespace MartinCostello.Benchmarks;
+
+#pragma warning disable CA1848
+
+/// <summary>
+/// A class representing a service to acquire a GitHub device token. This class cannot be inherited.
+/// </summary>
+/// <param name="client">The GitHub client to use.</param>
+/// <param name="tokenStore">The GitHub token store to use.</param>
+/// <param name="timeProvider">The <see cref="TimeProvider"/> to use.</param>
+/// <param name="logger">The logger to use.</param>
+public sealed class GitHubDeviceTokenService(
+    GitHubClient client,
+    GitHubTokenStore tokenStore,
+    TimeProvider timeProvider,
+    ILogger<GitHubDeviceTokenService> logger)
+{
+    /// <summary>
+    /// Gets a GitHub device code as an asynchronous operation.
+    /// </summary>
+    /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> to use.</param>
+    /// <returns>
+    /// A <see cref="Task"/> representing the asynchronous operation to get a device code.
+    /// </returns>
+    public async Task<GitHubDeviceCode> GetDeviceCodeAsync(CancellationToken cancellationToken = default)
+    {
+        return await client.GetDeviceCodeAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Waits for a GitHub access token as an asynchronous operation.
+    /// </summary>
+    /// <param name="deviceCode">The device code to use to acquire the access token.</param>
+    /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> to use.</param>
+    /// <returns>
+    /// A <see cref="Task"/> representing the asynchronous operation to get an access token
+    /// which returns <see langword="true"/> if the access token was acquired successfully or
+    /// <see langword="false"/> if an access token could not be acquired.
+    /// </returns>
+    public async Task<bool> WaitForAccessTokenAsync(GitHubDeviceCode deviceCode, CancellationToken cancellationToken = default)
+    {
+        var delay = TimeSpan.FromSeconds(deviceCode.RefreshIntervalInSeconds + 1);
+        var expiry = timeProvider.GetUtcNow().AddSeconds(deviceCode.ExpiresInSeconds);
+
+        while (timeProvider.GetUtcNow() < expiry)
+        {
+            var result = await client.GetAccessTokenAsync(deviceCode.DeviceCode, cancellationToken);
+
+            if (result.AccessToken is { Length: > 0 } token)
+            {
+                await tokenStore.StoreTokenAsync(token, cancellationToken);
+                return true;
+            }
+
+            switch (result.Error)
+            {
+                case "access_denied":
+                    logger.LogInformation("The user cancelled the authorization process.");
+                    return false;
+
+                case "device_flow_disabled":
+                    logger.LogWarning("The configured GitHub app has not enabled device flow.");
+                    return false;
+
+                case "expired_token":
+                    logger.LogInformation("The device token has expired.");
+                    return false;
+
+                default:
+                    break;
+            }
+
+            if (logger.IsEnabled(LogLevel.Debug))
+            {
+                logger.LogDebug(
+                    "Access token response: {Error}. Waiting {Interval} seconds.",
+                    result.Error,
+                    deviceCode.RefreshIntervalInSeconds);
+            }
+
+            await Task.Delay(delay, cancellationToken);
+        }
+
+        return false;
+    }
+}

--- a/src/Dashboard/GitHubService.cs
+++ b/src/Dashboard/GitHubService.cs
@@ -115,6 +115,29 @@ public sealed class GitHubService(
     }
 
     /// <summary>
+    /// Gets the URL for the connected application.
+    /// </summary>
+    /// <returns>
+    /// The URL for the connected application.
+    /// </returns>
+    public string ConnectionUrl()
+    {
+        if (CurrentUser is null)
+        {
+            return "#";
+        }
+
+        var current = options.Value;
+
+        var builder = new UriBuilder(current.GitHubServerUrl)
+        {
+            Path = $"settings/connections/applications/{current.GitHubClientId}",
+        };
+
+        return builder.Uri.ToString();
+    }
+
+    /// <summary>
     /// Loads the benchmarks for the specified branch as an asynchronous operation.
     /// </summary>
     /// <param name="branch">The branch to load the benchmarks for.</param>

--- a/src/Dashboard/Icons.cs
+++ b/src/Dashboard/Icons.cs
@@ -19,6 +19,11 @@ public static class Icons
     public static string ChartLine => "fa-solid fa-chart-line";
 
     /// <summary>
+    /// Gets the <c>check</c> icon.
+    /// </summary>
+    public static string Check => "fa-solid fa-check";
+
+    /// <summary>
     /// Gets the <c>clock</c> icon.
     /// </summary>
     public static string Clock => "fa-regular fa-clock";
@@ -37,6 +42,11 @@ public static class Icons
     /// Gets the <c>code-commit</c> icon.
     /// </summary>
     public static string CodeCommit => "fa-solid fa-code-commit";
+
+    /// <summary>
+    /// Gets the <c>copy</c> icon.
+    /// </summary>
+    public static string Copy => "fa-regular fa-copy";
 
     /// <summary>
     /// Gets the <c>database</c> icon.

--- a/src/Dashboard/Icons.cs
+++ b/src/Dashboard/Icons.cs
@@ -24,6 +24,11 @@ public static class Icons
     public static string Check => "fa-solid fa-check";
 
     /// <summary>
+    /// Gets the <c>clipboard</c> icon.
+    /// </summary>
+    public static string Clipboard => "fa-regular fa-clipboard";
+
+    /// <summary>
     /// Gets the <c>clock</c> icon.
     /// </summary>
     public static string Clock => "fa-regular fa-clock";
@@ -42,11 +47,6 @@ public static class Icons
     /// Gets the <c>code-commit</c> icon.
     /// </summary>
     public static string CodeCommit => "fa-solid fa-code-commit";
-
-    /// <summary>
-    /// Gets the <c>copy</c> icon.
-    /// </summary>
-    public static string Copy => "fa-regular fa-copy";
 
     /// <summary>
     /// Gets the <c>database</c> icon.

--- a/src/Dashboard/Icons.cs
+++ b/src/Dashboard/Icons.cs
@@ -84,6 +84,11 @@ public static class Icons
     public static string Plus => "fa-solid fa-plus";
 
     /// <summary>
+    /// Gets the <c>rotate-right</c> icon.
+    /// </summary>
+    public static string RotateRight => "fa-solid fa-rotate-right";
+
+    /// <summary>
     /// Gets the <c>right-from-bracket</c> icon.
     /// </summary>
     public static string RightFromBracket => "fa-solid fa-right-from-bracket";

--- a/src/Dashboard/Layout/MainLayout.razor
+++ b/src/Dashboard/Layout/MainLayout.razor
@@ -47,6 +47,7 @@
     </div>
 </footer>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.min.js" integrity="sha512-CQBWl4fJHWbryGE+Pc7UAxWMUMNMWzWxF4SQo9CgkJIN1kx6djDQZjh3Y8SZ1d+6I+1zze6Z7kHXO7q3UyZAWw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.11/clipboard.min.js" integrity="sha512-7O5pXpc0oCRrxk8RUfDYFgn0nO1t+jLuIOQdOMRp4APB7uZ4vSjspzp5y6YDtDs4VzUSTbWzBFZ/LKJhnyFOKw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 
 @code {
     protected async override Task OnAfterRenderAsync(bool firstRender)

--- a/src/Dashboard/Layout/Navbar.razor
+++ b/src/Dashboard/Layout/Navbar.razor
@@ -60,10 +60,7 @@
                     </li>
                 }
             </ul>
-            @{
-                var user = GitHubService.CurrentUser;
-            }
-            @if (user is not null)
+            @if (GitHubService.CurrentUser is { } user)
             {
                 <ul class="nav navbar-nav px-1">
                     <li>

--- a/src/Dashboard/Layout/Navbar.razor
+++ b/src/Dashboard/Layout/Navbar.razor
@@ -66,14 +66,18 @@
             @if (user is not null)
             {
                 <ul class="nav navbar-nav px-1">
-                    <span class="navbar-text"
-                          id="user-name"
-                          title="@(options.GitHubInstance) user"
-                          data-bs-toggle="tooltip"
-                          data-bs-title="Signed in as @(user.Login) (@(user.Name))">
-                        @(user.Login)
-                        <img src="@(user.AvatarUrl)" class="user-profile" alt="@(user.Name)" title="@(user.Name)" aria-hidden="true">
-                    </span>
+                    <li>
+                        <a class="nav-link"
+                           href="@(GitHubService.ConnectionUrl())"
+                           id="user-name"
+                           rel="noopener"
+                           target="_blank"
+                           data-bs-toggle="tooltip"
+                           data-bs-title="Signed in as @(user.Login) (@(user.Name))">
+                            @(user.Login)
+                            <img src="@(user.AvatarUrl)" class="user-profile" alt="@(user.Name)" title="@(user.Name)" aria-hidden="true">
+                        </a>
+                    </li>
                     <li>
                         <button class="btn btn-link navbar-btn nav-link"
                                 id="sign-out"

--- a/src/Dashboard/Models/GitHubAccessToken.cs
+++ b/src/Dashboard/Models/GitHubAccessToken.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Text.Json.Serialization;
+
+namespace MartinCostello.Benchmarks.Models;
+
+/// <summary>
+/// A class representing a GitHub access token. This class cannot be inherited.
+/// </summary>
+public sealed class GitHubAccessToken
+{
+    /// <summary>
+    /// Gets or sets the error code, if unsuccessful.
+    /// </summary>
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
+
+    /// <summary>
+    /// Gets or sets the access token.
+    /// </summary>
+    [JsonPropertyName("access_token")]
+    public string? AccessToken { get; set; }
+
+    /// <summary>
+    /// Gets or sets the type of the access token.
+    /// </summary>
+    [JsonPropertyName("token_type")]
+    public string? TokenType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the space-separated scopes(s) associated with the access token.
+    /// </summary>
+    [JsonPropertyName("scope")]
+    public string? Scopes { get; set; }
+}

--- a/src/Dashboard/Models/GitHubDeviceCode.cs
+++ b/src/Dashboard/Models/GitHubDeviceCode.cs
@@ -29,7 +29,7 @@ public sealed class GitHubDeviceCode
     public string VerificationUrl { get; set; } = default!;
 
     /// <summary>
-    /// Gets or sets the number of seconds of seconds before the device and user codes expire.
+    /// Gets or sets the number of seconds before the device and user codes expire.
     /// </summary>
     [JsonPropertyName("expires_in")]
     public int ExpiresInSeconds { get; set; }

--- a/src/Dashboard/Models/GitHubDeviceCode.cs
+++ b/src/Dashboard/Models/GitHubDeviceCode.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Text.Json.Serialization;
+
+namespace MartinCostello.Benchmarks.Models;
+
+/// <summary>
+/// A class representing a GitHub device code. This class cannot be inherited.
+/// </summary>
+public sealed class GitHubDeviceCode
+{
+    /// <summary>
+    /// Gets or sets the device code.
+    /// </summary>
+    [JsonPropertyName("device_code")]
+    public string DeviceCode { get; set; } = default!;
+
+    /// <summary>
+    /// Gets or sets the user code.
+    /// </summary>
+    [JsonPropertyName("user_code")]
+    public string UserCode { get; set; } = default!;
+
+    /// <summary>
+    /// Gets or sets the verification URL.
+    /// </summary>
+    [JsonPropertyName("verification_uri")]
+    public string VerificationUrl { get; set; } = default!;
+
+    /// <summary>
+    /// Gets or sets the number of seconds of seconds before the device and user codes expire.
+    /// </summary>
+    [JsonPropertyName("expires_in")]
+    public int ExpiresInSeconds { get; set; }
+
+    /// <summary>
+    /// Gets or sets the minimum number of seconds that must pass before re-requesting an access token.
+    /// </summary>
+    [JsonPropertyName("interval")]
+    public int RefreshIntervalInSeconds { get; set; }
+}

--- a/src/Dashboard/Pages/Token.razor
+++ b/src/Dashboard/Pages/Token.razor
@@ -1,5 +1,8 @@
 @page "/token"
 
+@inject GitHubDeviceTokenService TokenService
+@inject IJSRuntime JS
+
 @{
     var options = Options.Value;
     var tokenRequired = options.IsGitHubEnterprise;
@@ -29,171 +32,134 @@
                     }
                 </p>
                 <p class="card-text">
-                    @if (options.TokenScopes.Count > 1)
+                    @if (_deviceCode?.UserCode is { Length: > 0 } code)
                     {
-                        <text>
-                            Generate a new token with the following scopes and enter it into the form below:
-                            <ul>
-                                @foreach (var scope in options.TokenScopes)
-                                {
-                                    <li>
-                                        <code>@(scope)</code>
-                                    </li>
-                                }
-                            </ul>
-                        </text>
+                        <form>
+                            <div class="mb-3">
+                                <div class="input-group input-group-lg">
+                                    <span class="input-group-text" id="inputGroup-sizing-default">Code</span>
+                                    <input class="form-control font-monospace"
+                                           id="user-code"
+                                           label="The @(options.GitHubInstance) verification code"
+                                           readonly
+                                           type="text"
+                                           value="@(code)"
+                                           aria-describedby="user-code-help">
+                                    <button class="btn btn-lg btn-secondary copy-button"
+                                            data-clipboard-target="#user-code"
+                                            title="Copy to clipboard"
+                                            aria-label="Copy verification code to clipboard">
+                                        <span class="far fa-clipboard"></span>
+                                    </button>
+                                </div>
+                                <div class="form-text" id="user-code-help">
+                                    Use this code to allow @(options.BrandName) to generate an access token.
+                                </div>
+                            </div>
+                            @* TODO Add some sort of "please wait" message *@
+                            <div class="mb-3">
+                                <div class="d-grid gap-2">
+                                    <a class="btn btn-lg btn-github @(_authorizing ? "disabled" : string.Empty)"
+                                       href="@(_deviceCode?.VerificationUrl ?? "#")"
+                                       role="button"
+                                       target="_blank"
+                                       rel="noopener"
+                                       data-bs-toggle="tooltip"
+                                       data-bs-title="Authorize @(options.BrandName) to access your @(options.GitHubInstance) account"
+                                       @onclick="AuthorizeAsync">
+                                        Authorize
+                                        <Icon Name="@(Icons.Check)" />
+                                        <Icon Name="@(Icons.GitHub)" />
+                                        <Icon Name="@(Icons.Key)" />
+                                        @if (_authorizing)
+                                        {
+                                            <span class="ps-1">
+                                                <Spinner SpinnerType="@(SpinnerType.Border)" LoadingText="Authorizing..." />
+                                            </span>
+                                        }
+                                    </a>
+                                </div>
+                            </div>
+                        </form>
                     }
                     else
                     {
-                        <text>
-                            Generate a new token with the <code>@(options.TokenScopes.FirstOrDefault() ?? "public_repo")</code> scope and enter it into the form below.
-                        </text>
+                        <div class="d-flex justify-content-center">
+                            <Spinner SpinnerType="@(SpinnerType.Border)" Large="true" LoadingText="Generating code..." />
+                        </div>
                     }
                 </p>
-                <form class="row g-2 align-items-center" @onsubmit="(_) => { }">
-                    <div class="col-12">
-                        <label class="visually-hidden" for="github-token">
-                            @(options.GitHubInstance) Token
-                        </label>
-                        <div class="input-group">
-                            <div class="input-group-text">
-                                <Icon Name="@(Icons.GitHub)" />
-                                &nbsp;
-                                <Icon Name="@(Icons.Key)" />
-                            </div>
-                            <input autocomplete="off"
-                                   class="form-control @(GitHubService.InvalidToken ? "is-invalid" : string.Empty)"
-                                   id="token-input"
-                                   placeholder="ghp_repo-scoped-token"
-                                   required
-                                   title="Invalid @(options.GitHubInstance) token."
-                                   type="password"
-                                   data-1p-ignore
-                                   data-lpignore="true"
-                                   @oninput="TokenChanged"
-                                   @onkeydown="@TrySignInAsync"
-                                   @ref="_tokenInput">
+                @if (_deviceCode is not null && _authorizationFailed)
+                {
+                    @* TODO Make this look better *@
+                    <p class="card-text" id="authorization-failed">
+                        <div class="alert alert-warning" role="alert">
+                            <h5 class="fw-bolder">
+                                <span class="fa-stack">
+                                    <Icon Name="@(Icons.Key)" Stacked="true" />
+                                    <Icon Name="@(Icons.Ban)" Stacked="true" Color="danger" />
+                                </span>
+                                @(options.GitHubInstance) authorization failed
+                            </h5>
+                            <p>
+                                Possible causes:
+                                <ul class="fw-light">
+                                    <li>You did not enter the code above within @(TimeSpan.FromSeconds(_deviceCode.ExpiresInSeconds).Minutes) minutes</li>
+                                    <li>You cancelled the authorization process</li>
+                                </ul>
+                            </p>
+                            <p>
+                                <button class="btn btn-lg btn-primary" title="Refresh the code">
+                                    Try again
+                                    @* TODO Refresh the code and reset the UI *@
+                                </button>
+                            </p>
                         </div>
-                    </div>
-                    <div class="col-12 d-grid gap-2 d-xl-inline mx-auto">
-                        <a class="btn btn-github col-xl-2"
-                            href="@(_generateTokenUrl)"
-                            role="button"
-                            target="_blank"
-                            rel="noopener"
-                            data-bs-toggle="tooltip"
-                            data-bs-title="The @(options.GitHubInstance) access token must have at least the public_repo scope">
-                            Generate
-                            <Icon Name="@(Icons.Plus)" />
-                            <Icon Name="@(Icons.GitHub)" />
-                            <Icon Name="@(Icons.Key)" />
-                        </a>
-                        <button class="btn btn-primary col-xl-2"
-                                disabled="@(!HasToken)"
-                                id="save-token"
-                                type="button"
-                                @onclick="SignInAsync">
-                            Save
-                            <Icon Name="@(Icons.FloppyDisk)" />
-                            <Icon Name="@(Icons.GitHub)" />
-                            <Icon Name="@(Icons.Key)" />
-                        </button>
-                    </div>
-                </form>
+                    </p>
+                }
             </div>
         </div>
     </div>
 </div>
 
-@if (GitHubService.InvalidToken)
-{
-    <div class="row justify-content-center mx-4" id="invalid-token">
-        <div class="alert alert-warning col-12 col-md-8" role="alert">
-            <h5 class="fw-bolder">
-                <span class="fa-stack">
-                    <Icon Name="@(Icons.Key)" Stacked="true" />
-                    <Icon Name="@(Icons.Ban)" Stacked="true" Color="danger" />
-                </span>
-                Invalid @(options.GitHubInstance) token
-            </h5>
-            <p>
-                Possible causes:
-                <ul class="fw-light">
-                    <li>
-                        @if (options.IsGitHubEnterprise)
-                        {
-                            <text>The token is for GitHub.com not GitHub Enterprise</text>
-                        }
-                        else
-                        {
-                            <text>The token is not for GitHub.com</text>
-                        }
-                    </li>
-                    <li>The token has been deleted or regenerated</li>
-                    <li>The token has expired</li>
-                    <li>The token does not have the correct scopes</li>
-                </ul>
-            </p>
-        </div>
-    </div>
-}
-
 @code {
-    private string? _generateTokenUrl;
-    private string? _token;
-    private ElementReference _tokenInput;
+    private bool _authorizing;
+    private bool _authorizationFailed;
+    private GitHubDeviceCode? _deviceCode;
 
-    private bool HasToken => !string.IsNullOrEmpty(_token);
-
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
-        var options = Options.Value;
-
-        var description = Uri.EscapeDataString($"{options.RepositoryOwner} benchmarks");
-        var scopes = Uri.EscapeDataString(string.Join(',', options.TokenScopes));
-
-        var builder = new UriBuilder(Options.Value.GitHubServerUrl)
-        {
-            Path = "settings/tokens/new",
-            Query = $"description={description}&scopes={scopes}",
-        };
-
-        _generateTokenUrl = builder.Uri.ToString();
+        _deviceCode = await TokenService.GetDeviceCodeAsync();
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        await _tokenInput.FocusAsync();
-    }
-
-    private void TokenChanged(ChangeEventArgs args)
-    {
-        if (args.Value is string token)
+        if (_deviceCode is not null)
         {
-            _token = token;
+            await JS.InvokeVoidAsync("configureClipboard");
         }
     }
 
-    private async Task TrySignInAsync(KeyboardEventArgs args)
+    private async Task AuthorizeAsync()
     {
-        if (args.Code == "Enter" || args.Code == "NumpadEnter")
+        if (_deviceCode is null)
         {
-            await SignInAsync();
+            return;
         }
-    }
 
-    private async Task SignInAsync()
-    {
-        if (!string.IsNullOrWhiteSpace(_token))
+        _authorizing = true;
+
+        StateHasChanged();
+
+        if (await TokenService.WaitForAccessTokenAsync(_deviceCode))
         {
-            if (!await GitHubService.SignInAsync(_token))
-            {
-                StateHasChanged();
-            }
-            else
-            {
-                Navigation.NavigateTo(Routes.Home);
-            }
+            // TODO Fix the navbar not updating the authentication state
+            Navigation.NavigateTo(Routes.Home);
         }
+
+        StateHasChanged();
+
+        _authorizing = false;
+        _authorizationFailed = true;
     }
 }

--- a/src/Dashboard/Pages/Token.razor
+++ b/src/Dashboard/Pages/Token.razor
@@ -18,69 +18,72 @@
             </div>
             <div class="card-body">
                 <p class="card-text">
-                    @if (tokenRequired)
-                    {
-                        <text>
-                            A @(options.GitHubInstance) access token is required to load the data for this dashboard.
-                        </text>
-                    }
-                    else
-                    {
-                        <text>
-                            A @(options.GitHubInstance) access token can be configured to load the data for this dashboard to help avoid rate limiting.
-                        </text>
-                    }
+                    <div class="alert alert-@(tokenRequired ? "primary" : "info")" role="alert">
+                        A @(options.GitHubInstance) access token
+                        @if (tokenRequired)
+                        {
+                            <text>
+                                is required to load the data for this dashboard.
+                            </text>
+                        }
+                        else
+                        {
+                            <text>
+                                can be configured to load the data for this dashboard to help avoid rate limiting.
+                            </text>
+                        }
+                    </div>
                 </p>
                 <p class="card-text">
                     @if (_deviceCode?.UserCode is { Length: > 0 } code)
                     {
-                        <form>
-                            <div class="mb-3">
-                                <div class="input-group input-group-lg">
-                                    <span class="input-group-text" id="inputGroup-sizing-default">Code</span>
-                                    <input class="form-control font-monospace"
-                                           id="user-code"
-                                           label="The @(options.GitHubInstance) verification code"
-                                           readonly
-                                           type="text"
-                                           value="@(code)"
-                                           aria-describedby="user-code-help">
-                                    <button class="btn btn-lg btn-secondary copy-button"
-                                            data-clipboard-target="#user-code"
-                                            title="Copy to clipboard"
-                                            aria-label="Copy verification code to clipboard">
-                                        <span class="far fa-clipboard"></span>
-                                    </button>
-                                </div>
-                                <div class="form-text" id="user-code-help">
-                                    Use this code to allow @(options.BrandName) to generate an access token.
-                                </div>
+                        <div class="mb-3">
+                            <div class="input-group input-group-lg">
+                                <span class="input-group-text" id="inputGroup-sizing-default">Code</span>
+                                <input class="form-control font-monospace"
+                                       id="user-code"
+                                       label="The @(options.GitHubInstance) verification code"
+                                       readonly
+                                       type="text"
+                                       value="@(code)"
+                                       aria-describedby="user-code-help">
+                                <button class="btn btn-lg btn-primary copy-button"
+                                        autofocus
+                                        data-clipboard-target="#user-code"
+                                        title="Copy to clipboard"
+                                        aria-label="Copy verification code to clipboard">
+                                    <span class="far fa-clipboard"></span>
+                                </button>
                             </div>
-                            @* TODO Add some sort of "please wait" message *@
+                            <div class="form-text" id="user-code-help">
+                                Copy this code to allow @(options.BrandName) to generate an access token.
+                            </div>
+                        </div>
+                        @if (_authorizing)
+                        {
+                            <div class="d-flex justify-content-center">
+                                <Spinner SpinnerType="@(SpinnerType.Border)" Large="true" LoadingText="@($"Waiting for an access token for your {options.GitHubInstance} account")" />
+                            </div>
+                        }
+                        else if (!_authorizationFailed)
+                        {
                             <div class="mb-3">
                                 <div class="d-grid gap-2">
-                                    <a class="btn btn-lg btn-github @(_authorizing ? "disabled" : string.Empty)"
+                                    <a class="btn btn-lg btn-github"
                                        href="@(_deviceCode?.VerificationUrl ?? "#")"
                                        role="button"
                                        target="_blank"
                                        rel="noopener"
-                                       data-bs-toggle="tooltip"
-                                       data-bs-title="Authorize @(options.BrandName) to access your @(options.GitHubInstance) account"
+                                       title="Authorize @(options.BrandName) to access your {options.GitHubInstance} account"
                                        @onclick="AuthorizeAsync">
                                         Authorize
                                         <Icon Name="@(Icons.Check)" />
                                         <Icon Name="@(Icons.GitHub)" />
                                         <Icon Name="@(Icons.Key)" />
-                                        @if (_authorizing)
-                                        {
-                                            <span class="ps-1">
-                                                <Spinner SpinnerType="@(SpinnerType.Border)" LoadingText="Authorizing..." />
-                                            </span>
-                                        }
                                     </a>
                                 </div>
                             </div>
-                        </form>
+                        }
                     }
                     else
                     {
@@ -89,36 +92,33 @@
                         </div>
                     }
                 </p>
-                @if (_deviceCode is not null && _authorizationFailed)
-                {
-                    @* TODO Make this look better *@
-                    <p class="card-text" id="authorization-failed">
-                        <div class="alert alert-warning" role="alert">
-                            <h5 class="fw-bolder">
-                                <span class="fa-stack">
-                                    <Icon Name="@(Icons.Key)" Stacked="true" />
-                                    <Icon Name="@(Icons.Ban)" Stacked="true" Color="danger" />
-                                </span>
-                                @(options.GitHubInstance) authorization failed
-                            </h5>
-                            <p>
-                                Possible causes:
-                                <ul class="fw-light">
-                                    <li>You did not enter the code above within @(TimeSpan.FromSeconds(_deviceCode.ExpiresInSeconds).Minutes) minutes</li>
-                                    <li>You cancelled the authorization process</li>
-                                </ul>
-                            </p>
-                            <p>
-                                <button class="btn btn-lg btn-primary" title="Refresh the code">
-                                    Try again
-                                    @* TODO Refresh the code and reset the UI *@
-                                </button>
-                            </p>
-                        </div>
-                    </p>
-                }
             </div>
         </div>
+        @if (_deviceCode is not null && _authorizationFailed)
+        {
+            <div class="card mt-3">
+                <div class="card-header bg-danger text-white">
+                    <span class="fa-stack">
+                        <Icon Name="@(Icons.Key)" Stacked="true" />
+                        <Icon Name="@(Icons.Ban)" Stacked="true" Color="warning" />
+                    </span>
+                    @(options.GitHubInstance) authorization failed
+                </div>
+                <div class="card-body">
+                    <p class="card-text">
+                        Possible causes:
+                        <ul class="fw-light">
+                            <li>You did not enter the code above within @(TimeSpan.FromSeconds(_deviceCode.ExpiresInSeconds + 1).Minutes) minutes</li>
+                            <li>You cancelled the authorization process</li>
+                        </ul>
+                    </p>
+                    <button autofocus class="btn btn-primary" title="Refresh the code and try again" @onclick="RefreshCodeAsync">
+                        Refresh code
+                        <Icon Name="@(Icons.RotateRight)" />
+                    </button>
+                </div>
+            </div>
+        }
     </div>
 </div>
 
@@ -128,9 +128,7 @@
     private GitHubDeviceCode? _deviceCode;
 
     protected override async Task OnInitializedAsync()
-    {
-        _deviceCode = await TokenService.GetDeviceCodeAsync();
-    }
+        => await GenerateCodeAsync();
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -138,6 +136,23 @@
         {
             await JS.InvokeVoidAsync("configureClipboard");
         }
+    }
+
+    private async Task GenerateCodeAsync()
+    {
+        _deviceCode = await TokenService.GetDeviceCodeAsync();
+    }
+
+    private async Task RefreshCodeAsync()
+    {
+        _deviceCode = null;
+
+        await GenerateCodeAsync();
+
+        _authorizing = false;
+        _authorizationFailed = false;
+
+        StateHasChanged();
     }
 
     private async Task AuthorizeAsync()

--- a/src/Dashboard/Pages/Token.razor
+++ b/src/Dashboard/Pages/Token.razor
@@ -43,6 +43,7 @@
                                 <input class="form-control font-monospace"
                                        id="user-code"
                                        label="The @(options.GitHubInstance) verification code"
+                                       disabled="@(_authorizationFailed)"
                                        readonly
                                        type="text"
                                        value="@(code)"
@@ -171,9 +172,9 @@
 
         StateHasChanged();
 
-        if (await TokenService.WaitForAccessTokenAsync(_deviceCode))
+        if (await TokenService.WaitForAccessTokenAsync(_deviceCode) is { Length: > 0 } token &&
+            await GitHubService.SignInAsync(token))
         {
-            // TODO Fix the navbar not updating the authentication state
             Navigation.NavigateTo(Routes.Home);
         }
 

--- a/src/Dashboard/Pages/Token.razor
+++ b/src/Dashboard/Pages/Token.razor
@@ -53,7 +53,7 @@
                                         data-clipboard-target="#user-code"
                                         title="Copy to clipboard"
                                         aria-label="Copy verification code to clipboard">
-                                    <span class="far fa-clipboard"></span>
+                                        <Icon Name="@(Icons.Clipboard)" />
                                 </button>
                             </div>
                             <div class="form-text" id="user-code-help">
@@ -96,7 +96,7 @@
                 </p>
             </div>
         </div>
-        @if (_deviceCode is not null && _authorizationFailed)
+        @if (_deviceCode?.ExpiresInSeconds is { } expiry && _authorizationFailed)
         {
             <div class="card mt-3" id="authorization-failed">
                 <div class="card-header bg-danger text-white">
@@ -110,7 +110,7 @@
                     <p class="card-text">
                         Possible causes:
                         <ul class="fw-light">
-                            <li>You did not enter the code above within @(TimeSpan.FromSeconds(_deviceCode.ExpiresInSeconds + 1).Minutes) minutes</li>
+                            <li>You did not enter the code above within @(TimeSpan.FromSeconds(expiry + 1).Minutes) minutes</li>
                             <li>You cancelled the authorization process</li>
                         </ul>
                     </p>

--- a/src/Dashboard/Pages/Token.razor
+++ b/src/Dashboard/Pages/Token.razor
@@ -39,7 +39,7 @@
                     {
                         <div class="mb-3">
                             <div class="input-group input-group-lg">
-                                <span class="input-group-text" id="inputGroup-sizing-default">Code</span>
+                                <span class="input-group-text">Code</span>
                                 <input class="form-control font-monospace"
                                        id="user-code"
                                        label="The @(options.GitHubInstance) verification code"
@@ -71,6 +71,7 @@
                                 <div class="d-grid gap-2">
                                     <a class="btn btn-lg btn-github"
                                        href="@(_deviceCode?.VerificationUrl ?? "#")"
+                                       id="authorize"
                                        role="button"
                                        target="_blank"
                                        rel="noopener"
@@ -96,7 +97,7 @@
         </div>
         @if (_deviceCode is not null && _authorizationFailed)
         {
-            <div class="card mt-3">
+            <div class="card mt-3" id="authorization-failed">
                 <div class="card-header bg-danger text-white">
                     <span class="fa-stack">
                         <Icon Name="@(Icons.Key)" Stacked="true" />
@@ -112,7 +113,11 @@
                             <li>You cancelled the authorization process</li>
                         </ul>
                     </p>
-                    <button autofocus class="btn btn-primary" title="Refresh the code and try again" @onclick="RefreshCodeAsync">
+                    <button autofocus
+                            class="btn btn-primary"
+                            id="refresh-code"
+                            title="Refresh the code and try again"
+                            @onclick="RefreshCodeAsync">
                         Refresh code
                         <Icon Name="@(Icons.RotateRight)" />
                     </button>

--- a/src/Dashboard/Program.cs
+++ b/src/Dashboard/Program.cs
@@ -13,12 +13,15 @@ builder.RootComponents.Add<HeadOutlet>("head::after");
 
 builder.Services.Configure<DashboardOptions>(builder.Configuration.GetSection("Dashboard"));
 
+builder.Services.AddSingleton(TimeProvider.System);
+
 builder.Services.AddScoped(
     (provider) =>
         new HttpClient() { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 
 builder.Services.AddBlazoredLocalStorage();
 
+builder.Services.AddScoped<GitHubDeviceTokenService>();
 builder.Services.AddScoped<GitHubClient>();
 builder.Services.AddScoped<GitHubService>();
 builder.Services.AddScoped<GitHubTokenStore>();

--- a/src/Dashboard/wwwroot/app.css
+++ b/src/Dashboard/wwwroot/app.css
@@ -49,6 +49,10 @@ img.user-profile {
   word-break: unset;
 }
 
+.fa-spin {
+  --fa-animation-duration: 1.5s;
+}
+
 .no-resize {
   resize: none;
 }
@@ -178,6 +182,7 @@ a {
   text-decoration-color: white !important;
 }
 
+.btn-github:focus-visible,
 .btn-github:hover {
   background-color: color-mix(in srgb, black 80%, transparent);
   border-color: color-mix(in srgb, black, transparent);

--- a/src/Dashboard/wwwroot/app.css
+++ b/src/Dashboard/wwwroot/app.css
@@ -164,6 +164,20 @@ a {
   text-decoration-color: white;
 }
 
+.btn-github.disabled {
+  background-color: color-mix(in srgb, black 60%, transparent);
+  border-color: color-mix(in srgb, black, transparent);
+  color: white;
+  text-decoration-color: white;
+}
+
+.btn-github:active {
+  background-color: color-mix(in srgb, black 90%, transparent) !important;
+  border-color: white !important;
+  color: white !important;
+  text-decoration-color: white !important;
+}
+
 .btn-github:hover {
   background-color: color-mix(in srgb, black 80%, transparent);
   border-color: color-mix(in srgb, black, transparent);

--- a/src/Dashboard/wwwroot/app.js
+++ b/src/Dashboard/wwwroot/app.js
@@ -13,6 +13,19 @@ window.scrollToActiveChart = () => {
   }
 };
 
+window.configureClipboard = () => {
+  if ('ClipboardJS' in window) {
+    const selector = '.copy-button';
+    const clipboard = window['ClipboardJS'];
+    new clipboard(selector);
+    document.querySelectorAll(selector).forEach((element) => {
+      element.addEventListener('click', (event) => {
+        event.preventDefault();
+      });
+    });
+  }
+};
+
 window.configureToolTips = () => {
   const tooltips = [...document.querySelectorAll('[data-bs-toggle="tooltip"]')];
   tooltips.map((element) => new bootstrap.Tooltip(element));

--- a/src/Dashboard/wwwroot/appsettings.json
+++ b/src/Dashboard/wwwroot/appsettings.json
@@ -15,8 +15,10 @@
     },
     "GitHubApiUrl": "https://api.github.com",
     "GitHubApiVersion": "2022-11-28",
+    "GitHubClientId": "Ov23likdXQFqdqFST1Ec",
     "GitHubDataUrl": "https://raw.githubusercontent.com",
     "GitHubServerUrl": "https://github.com",
+    "GitHubTokenUrl": "https://api.martincostello.com/github/",
     "RepositoryOwner": "martincostello",
     "RepositoryName": "benchmarks",
     "Repositories": [

--- a/tests/Dashboard.Tests/Dashboard.Tests.csproj
+++ b/tests/Dashboard.Tests/Dashboard.Tests.csproj
@@ -12,6 +12,7 @@
     <ProjectReference Include="..\..\src\Dashboard\Dashboard.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="GitHubActionsTestLogger" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.Playwright" />

--- a/tests/Dashboard.Tests/Pages/TokenPage.cs
+++ b/tests/Dashboard.Tests/Pages/TokenPage.cs
@@ -8,27 +8,32 @@ namespace MartinCostello.Benchmarks.Pages;
 public sealed class TokenPage(IPage page) : AppPage(page)
 {
     public override async Task WaitForContentAsync()
-        => await Page.WaitForSelectorAsync(Selectors.TokenInput);
+        => await Page.WaitForSelectorAsync(Selectors.UserCode);
 
-    public async Task<bool> TokenIsInvalid()
+    public async Task Authorize()
+        => await Page.ClickAsync(Selectors.Authorize);
+
+    public async Task RefreshUserCode()
+        => await Page.ClickAsync(Selectors.RefreshCode);
+
+    public async Task<bool> AuthorizationFailed()
     {
-        await Page.WaitForSelectorAsync(Selectors.InvalidToken);
-        return await Page.IsVisibleAsync(Selectors.InvalidToken);
+        await Page.WaitForSelectorAsync(Selectors.AuthorizationFailed);
+        return await Page.IsVisibleAsync(Selectors.AuthorizationFailed);
     }
 
-    public async Task<TokenPage> WithToken(string token)
+    public async Task<string> UserCode()
     {
-        await Page.FillAsync(Selectors.TokenInput, token);
-        return this;
+        var element = await Page.WaitForSelectorAsync(Selectors.UserCode);
+        element.ShouldNotBeNull();
+        return await element.InputValueAsync();
     }
-
-    public async Task SaveToken()
-        => await Page.ClickAsync(Selectors.SaveButton);
 
     private static class Selectors
     {
-        internal const string InvalidToken = "id=invalid-token";
-        internal const string TokenInput = "id=token-input";
-        internal const string SaveButton = "id=save-token";
+        internal const string Authorize = "id=authorize";
+        internal const string AuthorizationFailed = "id=authorization-failed";
+        internal const string RefreshCode = "id=refresh-code";
+        internal const string UserCode = "id=user-code";
     }
 }

--- a/tests/Dashboard.Tests/Responses/access-token-authorized.json
+++ b/tests/Dashboard.Tests/Responses/access-token-authorized.json
@@ -1,0 +1,6 @@
+{
+  "error": null,
+  "access_token": "VALID_GITHUB_ACCESS_TOKEN",
+  "token_type": "bearer",
+  "scope": "public_repo"
+}

--- a/tests/Dashboard.Tests/Responses/access-token-expired.json
+++ b/tests/Dashboard.Tests/Responses/access-token-expired.json
@@ -1,0 +1,6 @@
+{
+  "error": "expired_token",
+  "access_token": null,
+  "token_type": null,
+  "scope": null
+}

--- a/tests/Dashboard.Tests/Responses/access-token-incorrect.json
+++ b/tests/Dashboard.Tests/Responses/access-token-incorrect.json
@@ -1,0 +1,6 @@
+{
+  "error": "incorrect_device_code",
+  "access_token": null,
+  "token_type": null,
+  "scope": null
+}

--- a/tests/Dashboard.Tests/Responses/access-token-pending.json
+++ b/tests/Dashboard.Tests/Responses/access-token-pending.json
@@ -1,0 +1,6 @@
+{
+  "error": "authorization_pending",
+  "access_token": null,
+  "token_type": null,
+  "scope": null
+}


### PR DESCRIPTION
Use GitHub device flow to acquire a GitHub access token instead of asking a user to generate one and then paste it in.
