### PR TITLE
UX tweaks

### DIFF
--- a/src/Dashboard/Pages/Home.razor
+++ b/src/Dashboard/Pages/Home.razor
@@ -29,7 +29,7 @@
                 <label class="input-group-text col-auto" for="branch" title="Branch" aria-label="Branch">
                     <Icon Name="@(Icons.CodeBranch)" FixedWidth="true" />
                 </label>
-                <select class="form-select" id="branch" name="branch" disabled="@(DisableBranches)" @onchange="BranchChangedAsync">
+                <select class="form-select" id="branch" name="branch" disabled="@(DisableBranches)" @onchange="@(BranchChangedAsync)">
                     @if (GitHubService.Branches.Count < 1)
                     {
                         <option>Loading...</option>
@@ -43,8 +43,7 @@
 
                         @foreach (var branch in GitHubService.Branches)
                         {
-                            var selected = branch == selectedBranch;
-                            <option value="@(branch)" selected="@(selected)">@(branch)</option>
+                            <option value="@(branch)" selected="@(branch == selectedBranch)">@(branch)</option>
                         }
                     }
                 </select>
@@ -67,8 +66,11 @@
             </strong>
             @if (GitHubService.Benchmarks.LastUpdated is { } timestamp && !ShowLoaders)
             {
-                <span title="@timestamp.ToString("s", CultureInfo.InvariantCulture)">
-                    @(timestamp.ToLocalTime().ToString("G"))
+                string text = timestamp.ToLocalTime().ToString("G");
+                string title = $"{timestamp:s} ({timestamp.Humanize()})";
+
+                <span title="@(title)">
+                    @(text)
                 </span>
             }
             else

--- a/src/Dashboard/Pages/Home.razor
+++ b/src/Dashboard/Pages/Home.razor
@@ -50,84 +50,102 @@
             </div>
         </div>
     </form>
-    <hr />
-    @if (_notFound && !ShowLoaders)
-    {
-        <div class="alert alert-danger m-2" id="no-benchmarks" role="alert">
-            Benchmark data not found for branch <span class="font-monospace">@(GitHubService.CurrentBranch)</span>.
-        </div>
-    }
-    else if (GitHubService.Benchmarks is not null)
-    {
-        <div class="header-item">
-            <strong class="header-label">
-                <Icon Name="@(Icons.Clock)" FixedWidth="true" />
-                Last Updated:
-            </strong>
-            @if (GitHubService.Benchmarks.LastUpdated is { } timestamp && !ShowLoaders)
-            {
-                string text = timestamp.ToLocalTime().ToString("G");
-                string title = $"{timestamp:s} ({timestamp.Humanize()})";
-
-                <span title="@(title)">
-                    @(text)
-                </span>
-            }
-            else
-            {
-                <Spinner />
-            }
-        </div>
-        <div class="header-item">
-            <strong class="header-label">
-                <Icon Name="@(Icons.GitHub)" FixedWidth="true" />
-                Repository:
-            </strong>
-            @if (GitHubService.CurrentRepository is null || ShowLoaders)
-            {
-                <Spinner />
-            }
-            else
-            {
-                <a class="header-content" href="@(GitHubService.CurrentRepository.HtmlUrl ?? "#")" rel="noopener" target="_blank">
-                    @(GitHubService.CurrentRepository.FullName)
-                </a>
-            }
-        </div>
-        <div class="header-item">
-            <strong class="header-label">
-                <Icon Name="@(Icons.CodeBranch)" FixedWidth="true" />
-                Branch:
-            </strong>
-            @if (GitHubService.CurrentBranch is null || ShowLoaders)
-            {
-                <Spinner Color="text-dark" />
-            }
-            else
-            {
-                <a class="font-monospace" href="@(GitHubService.BranchUrl())" rel="noopener" target="_blank">
-                    @(GitHubService.CurrentBranch)
-                </a>
-            }
-        </div>
-        <div class="header-item">
-            <strong class="header-label">
-                <Icon Name="@(Icons.CodeCommit)" FixedWidth="true" />
-                Commit:
-            </strong>
-            @if (GitHubService.CurrentCommit is null || ShowLoaders)
-            {
-                <Spinner Color="text-dark" />
-            }
-            else
-            {
-                <a class="font-monospace" href="@(GitHubService.CommitUrl())" rel="noopener" target="_blank">
-                    @(GitHubService.CurrentCommit[..7])
-                </a>
-            }
-        </div>
-    }
 </header>
+<hr />
+@if (_notFound && !ShowLoaders)
+{
+    <div class="alert alert-danger m-2" id="no-benchmarks" role="alert">
+        Benchmark data not found for branch <span class="font-monospace">@(GitHubService.CurrentBranch)</span>.
+    </div>
+}
+else if (GitHubService.Benchmarks is not null)
+{
+    <div class="container-fluid px-0">
+        <table class="table table-borderless table-sm w-auto">
+            <tbody>
+                <tr>
+                    <th class="text-end" scope="row">
+                        <Icon Name="@(Icons.Clock)" FixedWidth="true" />
+                        <strong>
+                            <span class="d-none d-sm-inline">Last </span>Updated:
+                        </strong>
+                    </th>
+                    <td>
+                        @if (GitHubService.Benchmarks.LastUpdated is { } timestamp && !ShowLoaders)
+                        {
+                            string text = timestamp.ToLocalTime().ToString("G");
+                            string title = $"{timestamp:s} ({timestamp.Humanize()})";
+
+                            <span title="@(title)">
+                                @(text)
+                            </span>
+                        }
+                        else
+                        {
+                            <Spinner />
+                        }
+                    </td>
+                </tr>
+                <tr>
+                    <th class="text-end" scope="row">
+                        <Icon Name="@(Icons.GitHub)" FixedWidth="true" />
+                        <strong>
+                            Repo<span class="d-none d-sm-inline">sitory</span>:
+                        </strong>
+                    </th>
+                    <td>
+                        @if (GitHubService.CurrentRepository is null || ShowLoaders)
+                        {
+                            <Spinner />
+                        }
+                        else
+                        {
+                            <a class="header-content" href="@(GitHubService.CurrentRepository.HtmlUrl ?? "#")" rel="noopener" target="_blank">
+                                @(GitHubService.CurrentRepository.FullName)
+                            </a>
+                        }
+                    </td>
+                </tr>
+                <tr>
+                    <th class="text-end" scope="row">
+                        <Icon Name="@(Icons.CodeBranch)" FixedWidth="true" />
+                        Branch:
+                    </th>
+                    <td>
+                        @if (GitHubService.CurrentBranch is null || ShowLoaders)
+                        {
+                            <Spinner Color="text-dark" />
+                        }
+                        else
+                        {
+                            <a class="font-monospace" href="@(GitHubService.BranchUrl())" rel="noopener" target="_blank">
+                                @(GitHubService.CurrentBranch)
+                            </a>
+                        }
+                    </td>
+                </tr>
+                <tr>
+                    <th class="text-end" scope="row">
+                        <Icon Name="@(Icons.CodeCommit)" FixedWidth="true" />
+                        Commit:
+                    </th>
+                    <td>
+                        @if (GitHubService.CurrentCommit is null || ShowLoaders)
+                        {
+                            <Spinner Color="text-dark" />
+                        }
+                        else
+                        {
+                            <a class="font-monospace" href="@(GitHubService.CommitUrl())" rel="noopener" target="_blank">
+                                @(GitHubService.CurrentCommit[..7])
+                            </a>
+                        }
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+}
 
 @if (ShowLoaders)
 {

--- a/src/Dashboard/wwwroot/app.css
+++ b/src/Dashboard/wwwroot/app.css
@@ -57,20 +57,6 @@ img.user-profile {
   resize: none;
 }
 
-.header-label {
-  margin-right: 0.25em;
-}
-
-@media (max-width: 576px) {
-  a.header-content {
-    display: inline-grid;
-    max-width: 55vw;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-}
-
 .benchmark-set {
   margin: 0.5em 0;
   width: 100%;

--- a/src/Dashboard/wwwroot/app.js
+++ b/src/Dashboard/wwwroot/app.js
@@ -113,14 +113,16 @@ window.renderChart = (canvasId, configString) => {
             const memory = context.datasetIndex === 1;
             let label;
             if (memory && item && item.result.bytesAllocated !== null) {
-              label = item.result.bytesAllocated.toString();
+              label = item.result.bytesAllocated.toFixed(2).toString();
               label += item.result.memoryUnit ?? ' bytes';
             } else {
-              label = item.result.value.toString();
+              label = item.result.value.toFixed(2).toString();
               const { range, unit } = item.result;
               label += unit;
               if (range) {
-                label += ` (${range})`;
+                const prefix = range.slice(0, 2);
+                const rangeValue = parseFloat(range.slice(2)).toPrecision(3);
+                label += ` (${prefix}${rangeValue})`;
               }
             }
             return label;


### PR DESCRIPTION
- Add relative time to the benchmark date titles.
- Reduce the precision of the values shown in the tooltips on the charts to 2 decimal places for the value and 3 significant figures for the range.
- Use a table to render the data above the charts so it looks better on mobile and aligns better too.
