### PR TITLE
Add unit tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,10 +37,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os: [ macos-latest, ubuntu-latest, windows-latest ]
         include:
           - os: macos-latest
+            os-name: macos
           - os: ubuntu-latest
+            os-name: linux
           - os: windows-latest
+            os-name: windows
 
     steps:
 
@@ -57,6 +61,13 @@ jobs:
     - name: Build, Test and Publish
       shell: pwsh
       run: ./build.ps1
+
+    - uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
+      name: Upload coverage to Codecov
+      with:
+        file: ./artifacts/coverage/coverage.cobertura.xml
+        flags: ${{ matrix.os-name }}
+        token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Publish dashboard
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -23,4 +23,24 @@
       <AssemblyMetadata Include="CommitBranch" Value="$(CommitBranch)" Condition=" $(CommitBranch) != '' " />
     </ItemGroup>
   </Target>
+  <PropertyGroup Condition=" '$(CollectCoverage)' == 'true' ">
+    <CoverletOutput>$([System.IO.Path]::Combine($(ArtifactsPath), 'coverage', 'coverage'))</CoverletOutput>
+    <ReportGeneratorOutputMarkdown Condition=" '$(ReportGeneratorOutputMarkdown)' == '' AND '$(GITHUB_SHA)' != '' ">true</ReportGeneratorOutputMarkdown>
+    <ReportGeneratorReportTypes>HTML</ReportGeneratorReportTypes>
+    <ReportGeneratorReportTypes Condition=" '$(ReportGeneratorOutputMarkdown)' == 'true' ">$(ReportGeneratorReportTypes);MarkdownSummaryGitHub</ReportGeneratorReportTypes>
+    <ReportGeneratorTargetDirectory>$([System.IO.Path]::Combine($(ArtifactsPath), 'coverage'))</ReportGeneratorTargetDirectory>
+  </PropertyGroup>
+  <Target Name="GenerateCoverageReports" AfterTargets="GenerateCoverageResultAfterTest" Condition=" '$(CollectCoverage)' == 'true' ">
+    <ReportGenerator ReportFiles="@(CoverletReport)" ReportTypes="$(ReportGeneratorReportTypes)" Tag="$(Version)" TargetDirectory="$(ReportGeneratorTargetDirectory)" Title="$(AssemblyName)" VerbosityLevel="Warning" />
+    <PropertyGroup Condition=" '$(ReportGeneratorOutputMarkdown)' == 'true' ">
+      <_ReportSummaryContent>&lt;details&gt;&lt;summary&gt;:chart_with_upwards_trend: &lt;b&gt;$(AssemblyName) Code Coverage report&lt;/b&gt;&lt;/summary&gt;</_ReportSummaryContent>
+      <_ReportSummaryContent>$(_ReportSummaryContent)$([System.Environment]::NewLine)</_ReportSummaryContent>
+      <_ReportSummaryContent>$(_ReportSummaryContent)$([System.Environment]::NewLine)</_ReportSummaryContent>
+      <_ReportSummaryContent>$(_ReportSummaryContent)$([System.IO.File]::ReadAllText('$([System.IO.Path]::Combine($(ReportGeneratorTargetDirectory), 'SummaryGithub.md'))'))</_ReportSummaryContent>
+      <_ReportSummaryContent>$(_ReportSummaryContent)$([System.Environment]::NewLine)</_ReportSummaryContent>
+      <_ReportSummaryContent>$(_ReportSummaryContent)$([System.Environment]::NewLine)</_ReportSummaryContent>
+      <_ReportSummaryContent>$(_ReportSummaryContent)&lt;/details&gt;</_ReportSummaryContent>
+    </PropertyGroup>
+    <WriteLinesToFile Condition=" '$(ReportGeneratorOutputMarkdown)' == 'true' " ContinueOnError="WarnAndContinue" File="$(GITHUB_STEP_SUMMARY)" Lines="$(_ReportSummaryContent)" />
+  </Target>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,6 +5,7 @@
   <ItemGroup>
     <PackageVersion Include="Blazored.LocalStorage" Version="4.5.0" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
+    <PackageVersion Include="JustEat.HttpClientInterception" Version="4.3.0" />
     <PackageVersion Include="Humanizer" Version="2.14.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.8" />
@@ -17,5 +18,6 @@
     <PackageVersion Include="Verify.Xunit" Version="26.3.1" />
     <PackageVersion Include="xunit" Version="2.9.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageVersion Include="Xunit.Combinatorial" Version="1.6.24" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,9 +7,11 @@
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageVersion Include="JustEat.HttpClientInterception" Version="4.3.0" />
     <PackageVersion Include="Humanizer" Version="2.14.1" />
+    <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.4.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.8.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.46.0" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Blazored.LocalStorage" Version="4.5.0" />
+    <PackageVersion Include="coverlet.msbuild" Version="6.0.2" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageVersion Include="JustEat.HttpClientInterception" Version="4.3.0" />
     <PackageVersion Include="Humanizer" Version="2.14.1" />
@@ -14,6 +15,7 @@
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.8.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.46.0" />
+    <PackageVersion Include="ReportGenerator" Version="5.3.8" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />
     <PackageVersion Include="Verify.ImageMagick" Version="3.5.0" />
     <PackageVersion Include="Verify.Playwright" Version="3.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Blazored.LocalStorage" Version="4.5.0" />
+    <PackageVersion Include="bunit" Version="1.31.3" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.2" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageVersion Include="JustEat.HttpClientInterception" Version="4.3.0" />

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Benchmarks Dashboard
 
 [![Deployment status][build-badge]][build-status]
+[![codecov][coverage-badge]][coverage-report]
 
 ## Introduction
 
@@ -40,6 +41,8 @@ This project is licensed under the [Apache 2.0][license] license.
 [blazor]: https://learn.microsoft.com/aspnet/core/blazor "ASP.NET Core Blazor"
 [build-badge]: https://github.com/martincostello/benchmarks-dashboard/actions/workflows/build.yml/badge.svg?branch=main&event=push
 [build-status]: https://github.com/martincostello/benchmarks-dashboard/actions?query=workflow%3Abuild+branch%3Amain+event%3Apush "Continuous Integration for this project"
+[coverage-badge]: https://codecov.io/gh/martincostello/benchmarks-dashboard/branch/main/graph/badge.svg
+[coverage-report]: https://codecov.io/gh/martincostello/benchmarks-dashboard "Code coverage report for this project"
 [dotnet-sdk]: https://dotnet.microsoft.com/download "Download the .NET SDK"
 [issues]: https://github.com/martincostello/benchmarks-dashboard/issues "Issues for this project on GitHub.com"
 [license]: https://www.apache.org/licenses/LICENSE-2.0.txt "The Apache 2.0 license"

--- a/src/Dashboard/GitHubClient.cs
+++ b/src/Dashboard/GitHubClient.cs
@@ -108,6 +108,7 @@ public sealed class GitHubClient(
         if (useApi)
         {
             await SetHeadersAsync(message.Headers, cancellationToken);
+            message.Headers.Accept.Clear();
             message.Headers.Add("Accept", "application/vnd.github.v3.raw");
         }
 

--- a/src/Dashboard/GitHubDeviceTokenService.cs
+++ b/src/Dashboard/GitHubDeviceTokenService.cs
@@ -24,9 +24,7 @@ public sealed partial class GitHubDeviceTokenService(
     /// A <see cref="Task"/> representing the asynchronous operation to get a device code.
     /// </returns>
     public async Task<GitHubDeviceCode> GetDeviceCodeAsync(CancellationToken cancellationToken = default)
-    {
-        return await client.GetDeviceCodeAsync(cancellationToken);
-    }
+        => await client.GetDeviceCodeAsync(cancellationToken);
 
     /// <summary>
     /// Waits for a GitHub access token as an asynchronous operation.

--- a/src/Dashboard/GitHubDeviceTokenService.cs
+++ b/src/Dashboard/GitHubDeviceTokenService.cs
@@ -71,9 +71,10 @@ public sealed partial class GitHubDeviceTokenService(
                 Log.AccessPending(logger, result.Error, deviceCode.RefreshIntervalInSeconds);
             }
 
-            await Task.Delay(delay, cancellationToken);
+            await Task.Delay(delay, timeProvider, cancellationToken);
         }
 
+        Log.TokenExpired(logger);
         return null;
     }
 

--- a/src/Dashboard/GitHubService.cs
+++ b/src/Dashboard/GitHubService.cs
@@ -51,7 +51,7 @@ public sealed class GitHubService(
     /// <summary>
     /// Gets a value indicating whether has a GitHub token configured.
     /// </summary>
-    public bool HasToken => !string.IsNullOrEmpty(tokenStore.GetToken());
+    public bool HasToken => !string.IsNullOrWhiteSpace(tokenStore.GetToken());
 
     /// <summary>
     /// Gets a value indicating whether the token is invalid.
@@ -152,6 +152,8 @@ public sealed class GitHubService(
         }
 
         CurrentBranch = branch;
+        CurrentCommit = null;
+
         Benchmarks = await client.GetBenchmarksAsync(CurrentRepository.Name, CurrentBranch, CurrentRepository.IsPublic);
 
         if (Benchmarks is null)
@@ -241,8 +243,13 @@ public sealed class GitHubService(
     {
         await tokenStore.StoreTokenAsync(string.Empty, cancellationToken);
 
+        var previous = CurrentUser;
         CurrentUser = null;
-        OnUserChanged?.Invoke(this, new(null));
+
+        if (previous != CurrentUser)
+        {
+            OnUserChanged?.Invoke(this, new(null));
+        }
     }
 
     /// <summary>

--- a/src/Dashboard/Layout/MainLayout.razor.cs
+++ b/src/Dashboard/Layout/MainLayout.razor.cs
@@ -6,7 +6,7 @@ using Microsoft.JSInterop;
 
 namespace MartinCostello.Benchmarks.Layout;
 
-public partial class MainLayout : LayoutComponentBase
+public partial class MainLayout
 {
     /// <summary>
     /// Gets the <see cref="IJSRuntime"/> to use.

--- a/src/Dashboard/Pages/Home.razor.cs
+++ b/src/Dashboard/Pages/Home.razor.cs
@@ -127,10 +127,11 @@ public partial class Home
 
                 if (item.Result.Range is { Length: > 0 } range)
                 {
+                    var prefix = range[0..2];
                     var rangeValue = double.Parse(range[2..], CultureInfo.InvariantCulture);
                     rangeValue *= Factor;
 
-                    item.Result.Range = $"± {rangeValue}";
+                    item.Result.Range = prefix + rangeValue;
                 }
             }
         }

--- a/src/Dashboard/Pages/Token.razor
+++ b/src/Dashboard/Pages/Token.razor
@@ -91,7 +91,7 @@
         </div>
         @if (_tokenGenerationFailed)
         {
-            <div class="card mt-3">
+            <div class="card mt-3" id="generation-failed">
                 <div class="card-header bg-danger text-white">
                     <Icon Name="@(Icons.GitHub)" />
                     @(Dashboard.GitHubInstance) authorization failed

--- a/tests/Dashboard.Tests/Components/BenchmarkSuiteTests.cs
+++ b/tests/Dashboard.Tests/Components/BenchmarkSuiteTests.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using Bunit;
+using MartinCostello.Benchmarks.Models;
+
+namespace MartinCostello.Benchmarks.Components;
+
+public class BenchmarkSuiteTests : DashboardTestContext
+{
+    [Fact]
+    public void BenchmarkSuite_Renders_Correctly()
+    {
+        // Arrange
+        string name = "Suite";
+        var benchmarks = new Dictionary<string, IList<BenchmarkItem>>()
+        {
+            ["Benchmark1"] = [new(new(), new() { Value = 1 })],
+            ["Benchmark2"] = [new(new(), new() { Value = 2 })],
+        };
+
+        JSInterop.SetupVoid("renderChart", (args) => args.Arguments.Count is 2 && args.Arguments[0] is "Suite-Benchmark1-chart");
+        JSInterop.SetupVoid("renderChart", (args) => args.Arguments.Count is 2 && args.Arguments[0] is "Suite-Benchmark2-chart");
+
+        // Act
+        var actual = RenderComponent<BenchmarkSuite>((builder) =>
+        {
+            builder.Add((p) => p.Name, name)
+                   .Add((p) => p.Benchmarks, benchmarks);
+        });
+
+        // Assert
+        var element = actual.Find($"[id='{name}']");
+        element.ShouldNotBeNull();
+
+        actual.Find("h2").TextContent.Trim().ShouldBe(name);
+
+        var charts = actual.FindAll(".benchmark-chart");
+        charts.Count.ShouldBe(2);
+
+        charts[0].HasAttribute("name");
+        charts[0].Attributes["name"]!.Value.ShouldBe("Benchmark1");
+
+        charts[1].HasAttribute("name");
+        charts[1].Attributes["name"]!.Value.ShouldBe("Benchmark2");
+    }
+}

--- a/tests/Dashboard.Tests/Components/BenchmarkSuiteTests.cs
+++ b/tests/Dashboard.Tests/Components/BenchmarkSuiteTests.cs
@@ -38,10 +38,7 @@ public class BenchmarkSuiteTests : DashboardTestContext
         var charts = actual.FindAll(".benchmark-chart");
         charts.Count.ShouldBe(2);
 
-        charts[0].HasAttribute("name");
-        charts[0].Attributes["name"]!.Value.ShouldBe("Benchmark1");
-
-        charts[1].HasAttribute("name");
-        charts[1].Attributes["name"]!.Value.ShouldBe("Benchmark2");
+        charts[0].GetAttribute("name").ShouldBe("Benchmark1");
+        charts[1].GetAttribute("name").ShouldBe("Benchmark2");
     }
 }

--- a/tests/Dashboard.Tests/Components/IconTests.cs
+++ b/tests/Dashboard.Tests/Components/IconTests.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using Bunit;
+
+namespace MartinCostello.Benchmarks.Components;
+
+public class IconTests : DashboardTestContext
+{
+    [Theory]
+    [InlineData("fa-brands fa-github", null, false, false, false, "fa-brands fa-github")]
+    [InlineData("fa-brands fa-github", "dark", false, false, false, "fa-brands fa-github text-dark")]
+    [InlineData("fa-brands fa-github", null, true, false, false, "fa-brands fa-github fa-fw")]
+    [InlineData("fa-brands fa-github", null, false, true, false, "fa-brands fa-github fa-spin")]
+    [InlineData("fa-brands fa-github", null, false, false, true, "fa-brands fa-github fa-stack-1x")]
+    [InlineData("fa-brands fa-github", "danger", true, true, true, "fa-brands fa-github text-danger fa-fw fa-spin fa-stack-1x")]
+    public void Icon_Renders_Correctly(
+        string name,
+        string? color,
+        bool fixedWidth,
+        bool spin,
+        bool stacked,
+        string expected)
+    {
+        // Act
+        var actual = RenderComponent<Icon>((builder) =>
+        {
+            builder.Add((p) => p.Name, name)
+                   .Add((p) => p.Color, color)
+                   .Add((p) => p.FixedWidth, fixedWidth)
+                   .Add((p) => p.Spin, spin)
+                   .Add((p) => p.Stacked, stacked);
+        });
+
+        // Assert
+        actual.MarkupMatches($@"<span class=""{expected}"" aria-hidden=""true""></span>");
+    }
+}

--- a/tests/Dashboard.Tests/Components/SpinnerTests.cs
+++ b/tests/Dashboard.Tests/Components/SpinnerTests.cs
@@ -39,13 +39,9 @@ public class SpinnerTests : DashboardTestContext
         // Assert
         var element = actual.Find($"[id={id}]");
 
-        element.HasAttribute("class");
-        element.HasAttribute("role");
-        element.HasAttribute("title");
-
-        element.Attributes["class"]!.Value.ShouldBe(expectedClasses);
-        element.Attributes["role"]!.Value.ShouldBe("status");
-        element.Attributes["title"]!.Value.ShouldBe(expectedTitle);
+        element.GetAttribute("class").ShouldBe(expectedClasses);
+        element.GetAttribute("role").ShouldBe("status");
+        element.GetAttribute("title").ShouldBe(expectedTitle);
         element.TextContent.ShouldBe(expectedTitle);
     }
 }

--- a/tests/Dashboard.Tests/Components/SpinnerTests.cs
+++ b/tests/Dashboard.Tests/Components/SpinnerTests.cs
@@ -38,7 +38,10 @@ public class SpinnerTests : DashboardTestContext
 
         // Assert
         var element = actual.Find($"[id={id}]");
-        element.ShouldNotBeNull();
+
+        element.HasAttribute("class");
+        element.HasAttribute("role");
+        element.HasAttribute("title");
 
         element.Attributes["class"]!.Value.ShouldBe(expectedClasses);
         element.Attributes["role"]!.Value.ShouldBe("status");

--- a/tests/Dashboard.Tests/Components/SpinnerTests.cs
+++ b/tests/Dashboard.Tests/Components/SpinnerTests.cs
@@ -43,8 +43,6 @@ public class SpinnerTests : DashboardTestContext
         element.Attributes["class"]!.Value.ShouldBe(expectedClasses);
         element.Attributes["role"]!.Value.ShouldBe("status");
         element.Attributes["title"]!.Value.ShouldBe(expectedTitle);
-
-        var span = actual.Find("span");
         element.TextContent.ShouldBe(expectedTitle);
     }
 }

--- a/tests/Dashboard.Tests/Components/SpinnerTests.cs
+++ b/tests/Dashboard.Tests/Components/SpinnerTests.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using Bunit;
+
+namespace MartinCostello.Benchmarks.Components;
+
+public class SpinnerTests : DashboardTestContext
+{
+    [Theory]
+    [InlineData("my-id", null, false, null, SpinnerType.Growing, "spinner spinner-grow spinner-grow-sm", "Loading...")]
+    [InlineData("my-id", null, false, null, SpinnerType.Border, "spinner spinner-border spinner-border-sm", "Loading...")]
+    [InlineData("my-id", "text-danger", false, null, SpinnerType.Growing, "spinner spinner-grow spinner-grow-sm text-danger", "Loading...")]
+    [InlineData("my-id", null, true, null, SpinnerType.Growing, "spinner spinner-grow spinner-xl", "Loading...")]
+    [InlineData("my-id", null, false, "Please wait...", SpinnerType.Growing, "spinner spinner-grow spinner-grow-sm", "Please wait...")]
+    public void Spinner_Renders_Correctly(
+        string id,
+        string? color,
+        bool large,
+        string? loadingText,
+        SpinnerType spinnerType,
+        string expectedClasses,
+        string expectedTitle)
+    {
+        // Act
+        var actual = RenderComponent<Spinner>((builder) =>
+        {
+            builder.Add((p) => p.Id, id)
+                   .Add((p) => p.Color, color)
+                   .Add((p) => p.Large, large)
+                   .Add((p) => p.SpinnerType, spinnerType);
+
+            if (loadingText is not null)
+            {
+                builder.Add((p) => p.LoadingText, loadingText);
+            }
+        });
+
+        // Assert
+        var element = actual.Find($"[id={id}]");
+        element.ShouldNotBeNull();
+
+        element.Attributes["class"]!.Value.ShouldBe(expectedClasses);
+        element.Attributes["role"]!.Value.ShouldBe("status");
+        element.Attributes["title"]!.Value.ShouldBe(expectedTitle);
+
+        var span = actual.Find("span");
+        element.TextContent.ShouldBe(expectedTitle);
+    }
+}

--- a/tests/Dashboard.Tests/Dashboard.Tests.csproj
+++ b/tests/Dashboard.Tests/Dashboard.Tests.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="GitHubActionsTestLogger" />
+    <PackageReference Include="JustEat.HttpClientInterception" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.Playwright" />
     <PackageReference Include="Shouldly" />
@@ -22,6 +23,7 @@
     <PackageReference Include="Verify.Xunit" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Xunit.Combinatorial" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="Shouldly" />

--- a/tests/Dashboard.Tests/Dashboard.Tests.csproj
+++ b/tests/Dashboard.Tests/Dashboard.Tests.csproj
@@ -39,6 +39,6 @@
     <CoverletOutputFormat>cobertura,json</CoverletOutputFormat>
     <Exclude>[*.Test*]*,[xunit.*]*</Exclude>
     <ExcludeByAttribute>GeneratedCodeAttribute</ExcludeByAttribute>
-    <Threshold>20</Threshold>
+    <Threshold>35</Threshold>
   </PropertyGroup>
 </Project>

--- a/tests/Dashboard.Tests/Dashboard.Tests.csproj
+++ b/tests/Dashboard.Tests/Dashboard.Tests.csproj
@@ -40,6 +40,6 @@
     <CoverletOutputFormat>cobertura,json</CoverletOutputFormat>
     <Exclude>[*.Test*]*,[xunit.*]*</Exclude>
     <ExcludeByAttribute>GeneratedCodeAttribute</ExcludeByAttribute>
-    <Threshold>40</Threshold>
+    <Threshold>70</Threshold>
   </PropertyGroup>
 </Project>

--- a/tests/Dashboard.Tests/Dashboard.Tests.csproj
+++ b/tests/Dashboard.Tests/Dashboard.Tests.csproj
@@ -13,12 +13,14 @@
   </ItemGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="coverlet.msbuild" />
     <PackageReference Include="GitHubActionsTestLogger" />
     <PackageReference Include="JustEat.HttpClientInterception" />
     <PackageReference Include="MartinCostello.Logging.XUnit" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.Playwright" />
+    <PackageReference Include="ReportGenerator" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="Verify.ImageMagick" />
     <PackageReference Include="Verify.Playwright" />
@@ -32,4 +34,11 @@
     <Using Include="Xunit" />
     <Using Include="Xunit.Abstractions" />
   </ItemGroup>
+  <PropertyGroup Condition=" '$(BuildingInsideVisualStudio)' != 'true' ">
+    <CollectCoverage>true</CollectCoverage>
+    <CoverletOutputFormat>cobertura,json</CoverletOutputFormat>
+    <Exclude>[*.Test*]*,[xunit.*]*</Exclude>
+    <ExcludeByAttribute>GeneratedCodeAttribute</ExcludeByAttribute>
+    <Threshold>20</Threshold>
+  </PropertyGroup>
 </Project>

--- a/tests/Dashboard.Tests/Dashboard.Tests.csproj
+++ b/tests/Dashboard.Tests/Dashboard.Tests.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="bunit" />
     <PackageReference Include="coverlet.msbuild" />
     <PackageReference Include="GitHubActionsTestLogger" />
     <PackageReference Include="JustEat.HttpClientInterception" />
@@ -39,6 +40,6 @@
     <CoverletOutputFormat>cobertura,json</CoverletOutputFormat>
     <Exclude>[*.Test*]*,[xunit.*]*</Exclude>
     <ExcludeByAttribute>GeneratedCodeAttribute</ExcludeByAttribute>
-    <Threshold>35</Threshold>
+    <Threshold>40</Threshold>
   </PropertyGroup>
 </Project>

--- a/tests/Dashboard.Tests/Dashboard.Tests.csproj
+++ b/tests/Dashboard.Tests/Dashboard.Tests.csproj
@@ -15,6 +15,8 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="GitHubActionsTestLogger" />
     <PackageReference Include="JustEat.HttpClientInterception" />
+    <PackageReference Include="MartinCostello.Logging.XUnit" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.Playwright" />
     <PackageReference Include="Shouldly" />

--- a/tests/Dashboard.Tests/DashboardOptionsTests.cs
+++ b/tests/Dashboard.Tests/DashboardOptionsTests.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.Benchmarks;
+
+public static class DashboardOptionsTests
+{
+    [Theory]
+    [InlineData("https://api.github.com", false, "GitHub")]
+    [InlineData("https://github.corp/api/v3", true, "GitHub Enterprise")]
+    [InlineData("https://github.local/api/v3", true, "GitHub Enterprise")]
+    public static void Determines_GitHub_Enterprise_Correctly(
+        string githubApiUrl,
+        bool expectedIsGitHubEnterprise,
+        string expectedGitHubInstance)
+    {
+        // Arrange
+        var target = new DashboardOptions()
+        {
+            GitHubApiUrl = new(githubApiUrl),
+        };
+
+        // Act and Assert
+        target.IsGitHubEnterprise.ShouldBe(expectedIsGitHubEnterprise);
+        target.GitHubInstance.ShouldBe(expectedGitHubInstance);
+    }
+}

--- a/tests/Dashboard.Tests/DashboardTestContext.cs
+++ b/tests/Dashboard.Tests/DashboardTestContext.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using Blazored.LocalStorage;
+using Bunit;
+using JustEat.HttpClientInterception;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MartinCostello.Benchmarks;
+
+public abstract class DashboardTestContext : TestContext
+{
+    protected DashboardTestContext()
+        : base()
+    {
+        Interceptor = new HttpClientInterceptorOptions().ThrowsOnMissingRegistration();
+        LocalStorage = new();
+        Options = new()
+        {
+            BenchmarkFileName = "data.json",
+            GitHubApiUrl = new("https://api.github.local"),
+            GitHubApiVersion = "2022-11-28",
+            GitHubClientId = "dkd73mfo9ASgjsfnhJD8",
+            GitHubServerUrl = new("https://github.local"),
+            Repositories = ["benchmarks-demo", "website"],
+            RepositoryOwner = "martincostello",
+            RepositoryName = "benchmarks",
+            TokenScopes = ["public_repo"],
+        };
+
+        Services.AddSingleton((_) => Microsoft.Extensions.Options.Options.Create(Options));
+        Services.AddSingleton((_) => Interceptor.CreateHttpClient());
+
+        Services.AddSingleton<ILocalStorageService>(LocalStorage);
+        Services.AddSingleton<ISyncLocalStorageService>(LocalStorage);
+
+        Services.AddSingleton<GitHubClient>();
+        Services.AddSingleton<GitHubService>();
+        Services.AddSingleton<GitHubTokenStore>();
+    }
+
+    protected HttpClientInterceptorOptions Interceptor { get; }
+
+    protected DashboardOptions Options { get; }
+
+    private LocalStorage LocalStorage { get; }
+}

--- a/tests/Dashboard.Tests/DashboardTestContext.cs
+++ b/tests/Dashboard.Tests/DashboardTestContext.cs
@@ -21,6 +21,7 @@ public abstract class DashboardTestContext : TestContext
             GitHubApiUrl = new("https://api.github.local"),
             GitHubApiVersion = "2022-11-28",
             GitHubClientId = "dkd73mfo9ASgjsfnhJD8",
+            GitHubTokenUrl = new("https://github.local"),
             GitHubServerUrl = new("https://github.local"),
             Repositories = ["benchmarks-demo", "website"],
             RepositoryOwner = "martincostello",
@@ -31,9 +32,12 @@ public abstract class DashboardTestContext : TestContext
         Services.AddSingleton((_) => Microsoft.Extensions.Options.Options.Create(Options));
         Services.AddSingleton((_) => Interceptor.CreateHttpClient());
 
+        Services.AddSingleton(TimeProvider.System);
+
         Services.AddSingleton<ILocalStorageService>(LocalStorage);
         Services.AddSingleton<ISyncLocalStorageService>(LocalStorage);
 
+        Services.AddSingleton<GitHubDeviceTokenService>();
         Services.AddSingleton<GitHubClient>();
         Services.AddSingleton<GitHubService>();
         Services.AddSingleton<GitHubTokenStore>();

--- a/tests/Dashboard.Tests/DashboardTests.cs
+++ b/tests/Dashboard.Tests/DashboardTests.cs
@@ -120,18 +120,7 @@ public class DashboardTests(
                 "DotNetBenchmarks.TodoAppBenchmarks",
                 "DotNetBenchmarks.TodoAppBenchmarks.GetAllTodos");
 
-            var screenshot = await chart.ScreenshotAsync(new()
-            {
-                Quality = 50,
-                Type = ScreenshotType.Jpeg,
-            });
-
-            using (var stream = new MemoryStream(screenshot))
-            {
-                await Verify(new Target("png", stream))
-                    .UseDirectory("snapshots")
-                    .UseTextForParameters($"{browserType}_{browserChannel}_benchmarks-demo");
-            }
+            await VerifyScreenshot(chart, $"{browserType}_{browserChannel}_benchmarks-demo");
 
             // Arrange
             var token = await dashboard.SignInAsync();
@@ -223,18 +212,7 @@ public class DashboardTests(
 
             chart.ShouldNotBeNull();
 
-            screenshot = await chart.ScreenshotAsync(new()
-            {
-                Quality = 50,
-                Type = ScreenshotType.Jpeg,
-            });
-
-            using (var stream = new MemoryStream(screenshot))
-            {
-                await Verify(new Target("png", stream))
-                    .UseDirectory("snapshots")
-                    .UseTextForParameters($"{browserType}_{browserChannel}_website");
-            }
+            await VerifyScreenshot(chart, $"{browserType}_{browserChannel}_website");
 
             // Act
             await dashboard.SignOutAsync();
@@ -263,6 +241,20 @@ public class DashboardTests(
         {
             throw new InvalidOperationException($"Playwright exited with code {exitCode}");
         }
+    }
+
+    private static async Task VerifyScreenshot(IElementHandle element, string parametersText)
+    {
+        var screenshot = await element.ScreenshotAsync(new()
+        {
+            Quality = 50,
+            Type = ScreenshotType.Jpeg,
+        });
+
+        using var stream = new MemoryStream(screenshot);
+        await Verify(new Target("png", stream))
+            .UseDirectory("snapshots")
+            .UseTextForParameters(parametersText);
     }
 
     private static async Task ConfigureMocksAsync(

--- a/tests/Dashboard.Tests/DashboardTests.cs
+++ b/tests/Dashboard.Tests/DashboardTests.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System.Runtime.CompilerServices;
-using MartinCostello.Benchmarks.Pages;
+using MartinCostello.Benchmarks.PageModels;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Playwright;
 

--- a/tests/Dashboard.Tests/GitHubClientTests.cs
+++ b/tests/Dashboard.Tests/GitHubClientTests.cs
@@ -1,0 +1,342 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using JustEat.HttpClientInterception;
+
+namespace MartinCostello.Benchmarks;
+
+public class GitHubClientTests
+{
+    public GitHubClientTests()
+    {
+        Options = new()
+        {
+            BenchmarkFileName = "data.json",
+            GitHubApiUrl = new("https://api.github.local"),
+            GitHubApiVersion = "2022-11-28",
+            GitHubClientId = "dkd73mfo9ASgjsfnhJD8",
+            GitHubDataUrl = new("https://raw.githubusercontent.local"),
+            GitHubTokenUrl = new("https://github.local"),
+            RepositoryOwner = "octocat",
+            RepositoryName = "benchmarks",
+            TokenScopes = ["public_repo"],
+        };
+
+        Interceptor = new HttpClientInterceptorOptions().ThrowsOnMissingRegistration();
+        Interceptor.CreateHttpClient();
+
+        var options = Microsoft.Extensions.Options.Options.Create(Options);
+        var storage = new LocalStorage();
+
+        TokenStore = new GitHubTokenStore(
+            storage,
+            storage,
+            options);
+
+        Target = new(Interceptor.CreateHttpClient(), TokenStore, options);
+    }
+
+    private HttpClientInterceptorOptions Interceptor { get; }
+
+    private DashboardOptions Options { get; }
+
+    private GitHubTokenStore TokenStore { get; }
+
+    private GitHubClient Target { get; }
+
+    [Fact]
+    public async Task Can_Get_Device_Code()
+    {
+        // Arrange
+        var builder = new HttpRequestInterceptionBuilder()
+            .ForPost()
+            .ForUrl("https://github.local/login/device/code?client_id=dkd73mfo9ASgjsfnhJD8&scope=public_repo")
+            .WithJsonContent(
+                new
+                {
+                    device_code = "3584d83530557fdd1f46af8289938c8ef79f9dc5",
+                    expires_in = 900,
+                    interval = 5,
+                    user_code = "WDJB-MJHT",
+                    verification_uri = "https://github.local/login/device",
+                });
+
+        builder.RegisterWith(Interceptor);
+
+        // Act
+        var actual = await Target.GetDeviceCodeAsync();
+
+        // Assert
+        actual.ShouldNotBeNull();
+        actual.DeviceCode.ShouldBe("3584d83530557fdd1f46af8289938c8ef79f9dc5");
+        actual.ExpiresInSeconds.ShouldBe(900);
+        actual.RefreshIntervalInSeconds.ShouldBe(5);
+        actual.UserCode.ShouldBe("WDJB-MJHT");
+        actual.VerificationUrl.ShouldBe("https://github.local/login/device");
+    }
+
+    [Fact]
+    public async Task Can_Get_Access_Code()
+    {
+        // Arrange
+        var builder = new HttpRequestInterceptionBuilder()
+            .ForPost()
+            .ForUrl("https://github.local/login/oauth/access_token?client_id=dkd73mfo9ASgjsfnhJD8&device_code=3584d83530557fdd1f46af8289938c8ef79f9dc5&grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code")
+            .WithJsonContent(
+                new
+                {
+                    access_token = "not_a_real_token",
+                    token_type = "bearer",
+                    scope = "public_repo",
+                });
+
+        builder.RegisterWith(Interceptor);
+
+        // Act
+        var actual = await Target.GetAccessTokenAsync("3584d83530557fdd1f46af8289938c8ef79f9dc5");
+
+        // Assert
+        actual.ShouldNotBeNull();
+        actual.AccessToken.ShouldBe("not_a_real_token");
+        actual.Error.ShouldBeNull();
+        actual.TokenType.ShouldBe("bearer");
+        actual.Scopes.ShouldBe("public_repo");
+    }
+
+    [Fact]
+    public async Task Can_Get_Benchmarks_Public_GitHub_Repository()
+    {
+        // Arrange
+        Options.GitHubApiUrl = new("https://api.github.com");
+
+        var builder = new HttpRequestInterceptionBuilder()
+            .ForGet()
+            .ForUrl("https://raw.githubusercontent.local/octocat/benchmarks/my-branch/my-repository/data.json")
+            .WithJsonContent(
+                new
+                {
+                    lastUpdated = 1725355699000,
+                    repoUrl = "https://github.local/octocat/my-repository",
+                });
+
+        builder.RegisterWith(Interceptor);
+
+        string repository = "my-repository";
+        string branch = "my-branch";
+        bool isPublic = true;
+
+        // Act
+        var actual = await Target.GetBenchmarksAsync(repository, branch, isPublic);
+
+        // Assert
+        actual.ShouldNotBeNull();
+        actual.LastUpdated.ShouldBe(new(2024, 09, 03, 09, 28, 19, TimeSpan.Zero));
+        actual.RepositoryUrl.ShouldBe("https://github.local/octocat/my-repository");
+    }
+
+    [Fact]
+    public async Task Can_Get_Benchmarks_Private_GitHub_Repository()
+    {
+        // Arrange
+        await TokenStore.StoreTokenAsync("foo");
+
+        Options.GitHubApiUrl = new("https://api.github.com");
+
+        var builder = new HttpRequestInterceptionBuilder()
+            .ForGet()
+            .ForUrl("https://api.github.com/repos/octocat/benchmarks/contents/my-repository/data.json?ref=my-branch")
+            .ForRequestHeader("Accept", "application/vnd.github.v3.raw")
+            .ForRequestHeader("Authorization", "token foo")
+            .ForRequestHeader("X-GitHub-Api-Version", "2022-11-28")
+            .WithJsonContent(
+                new
+                {
+                    lastUpdated = 1725355699000,
+                    repoUrl = "https://github.local/octocat/my-repository",
+                });
+
+        builder.RegisterWith(Interceptor);
+
+        string repository = "my-repository";
+        string branch = "my-branch";
+        bool isPublic = false;
+
+        // Act
+        var actual = await Target.GetBenchmarksAsync(repository, branch, isPublic);
+
+        // Assert
+        actual.ShouldNotBeNull();
+        actual.LastUpdated.ShouldBe(new(2024, 09, 03, 09, 28, 19, TimeSpan.Zero));
+        actual.RepositoryUrl.ShouldBe("https://github.local/octocat/my-repository");
+    }
+
+    [Theory]
+    [CombinatorialData]
+    public async Task Can_Get_Benchmarks_GitHub_Enterprise_Repository(bool isPublic)
+    {
+        // Arrange
+        await TokenStore.StoreTokenAsync("foo");
+
+        var builder = new HttpRequestInterceptionBuilder()
+            .ForGet()
+            .ForUrl("https://api.github.local/repos/octocat/benchmarks/contents/my-repository/data.json?ref=my-branch")
+            .ForRequestHeader("Accept", "application/vnd.github.v3.raw")
+            .ForRequestHeader("Authorization", "token foo")
+            .ForRequestHeader("X-GitHub-Api-Version", "2022-11-28")
+            .WithJsonContent(
+                new
+                {
+                    lastUpdated = 1725355699000,
+                    repoUrl = "https://github.local/octocat/my-repository",
+                });
+
+        builder.RegisterWith(Interceptor);
+
+        string repository = "my-repository";
+        string branch = "my-branch";
+
+        // Act
+        var actual = await Target.GetBenchmarksAsync(repository, branch, isPublic);
+
+        // Assert
+        actual.ShouldNotBeNull();
+        actual.LastUpdated.ShouldBe(new(2024, 09, 03, 09, 28, 19, TimeSpan.Zero));
+        actual.RepositoryUrl.ShouldBe("https://github.local/octocat/my-repository");
+    }
+
+    [Fact]
+    public async Task Can_Get_Benchmarks_Returns_Null_If_Not_Found()
+    {
+        // Arrange
+        var builder = new HttpRequestInterceptionBuilder()
+            .ForGet()
+            .ForUrl("https://api.github.local/repos/octocat/benchmarks/contents/my-repository/data.json?ref=my-branch")
+            .WithStatus(404);
+
+        builder.RegisterWith(Interceptor);
+
+        string repository = "my-repository";
+        string branch = "my-branch";
+        bool isPublic = true;
+
+        // Act
+        var actual = await Target.GetBenchmarksAsync(repository, branch, isPublic);
+
+        // Assert
+        actual.ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData("public", true)]
+    [InlineData("internal", false)]
+    [InlineData("private", false)]
+    public async Task Can_Get_Repository(string visibility, bool expectedIsPublic)
+    {
+        // Arrange
+        await TokenStore.StoreTokenAsync("foo");
+
+        var builder = new HttpRequestInterceptionBuilder()
+            .ForGet()
+            .ForUrl("https://api.github.local/repos/octocat/my-repository")
+            .ForRequestHeader("Accept", "application/vnd.github+json")
+            .ForRequestHeader("X-GitHub-Api-Version", "2022-11-28")
+            .WithJsonContent(
+                new
+                {
+                    default_branch = "main",
+                    full_name = "octocat/my-repository",
+                    html_url = "https://github.local/octocat/my-repository",
+                    name = "my-repository",
+                    owner = new
+                    {
+                        login = "octocat",
+                    },
+                    visibility,
+                });
+
+        builder.RegisterWith(Interceptor);
+
+        string owner = "octocat";
+        string repository = "my-repository";
+
+        // Act
+        var actual = await Target.GetRepositoryAsync(owner, repository);
+
+        // Assert
+        actual.ShouldNotBeNull();
+        actual.DefaultBranch.ShouldBe("main");
+        actual.FullName.ShouldBe("octocat/my-repository");
+        actual.HtmlUrl.ShouldBe("https://github.local/octocat/my-repository");
+        actual.Name.ShouldBe("my-repository");
+        actual.Owner.ShouldNotBeNull();
+        actual.Owner.Login.ShouldBe("octocat");
+        actual.Visibility.ShouldBe(visibility);
+        actual.IsPublic.ShouldBe(expectedIsPublic);
+    }
+
+    [Fact]
+    public async Task Can_Get_Branches()
+    {
+        // Arrange
+        await TokenStore.StoreTokenAsync("foo");
+
+        var builder = new HttpRequestInterceptionBuilder()
+            .ForGet()
+            .ForUrl("https://api.github.local/repos/octocat/my-repository/branches")
+            .ForRequestHeader("Accept", "application/vnd.github+json")
+            .ForRequestHeader("X-GitHub-Api-Version", "2022-11-28")
+            .WithJsonContent(
+                new[]
+                {
+                    new { name = "main" },
+                    new { name = "my-new-feature" },
+                });
+
+        builder.RegisterWith(Interceptor);
+
+        string owner = "octocat";
+        string repository = "my-repository";
+
+        // Act
+        var actual = await Target.GetRepositoryBranchesAsync(owner, repository);
+
+        // Assert
+        actual.ShouldNotBeNull();
+        actual.Count.ShouldBe(2);
+        actual.ShouldAllBe((p) => p != null);
+        actual.Select((p) => p.Name).ShouldBe(["main", "my-new-feature"]);
+    }
+
+    [Fact]
+    public async Task Can_Get_User()
+    {
+        // Arrange
+        Options.GitHubApiUrl = new("https://github.local/api/v3/");
+
+        await TokenStore.StoreTokenAsync("foo");
+
+        var builder = new HttpRequestInterceptionBuilder()
+            .ForGet()
+            .ForUrl("https://github.local/api/v3/user")
+            .ForRequestHeader("Accept", "application/vnd.github+json")
+            .ForRequestHeader("X-GitHub-Api-Version", "2022-11-28")
+            .WithJsonContent(
+                new
+                {
+                    avatar_url = "https://avatars.githubusercontent.com/u/583231?v=4",
+                    login = "octocat",
+                    name = "The Octocat",
+                });
+
+        builder.RegisterWith(Interceptor);
+
+        // Act
+        var actual = await Target.GetUserAsync();
+
+        // Assert
+        actual.ShouldNotBeNull();
+        actual.AvatarUrl.ShouldBe("https://avatars.githubusercontent.com/u/583231?v=4");
+        actual.Login.ShouldBe("octocat");
+        actual.Name.ShouldBe("The Octocat");
+    }
+}

--- a/tests/Dashboard.Tests/GitHubDeviceTokenServiceTests.cs
+++ b/tests/Dashboard.Tests/GitHubDeviceTokenServiceTests.cs
@@ -55,6 +55,29 @@ public class GitHubDeviceTokenServiceTests
     private GitHubDeviceTokenService Target { get; }
 
     [Fact]
+    public async Task Can_Get_Device_Code()
+    {
+        // Arrange
+        var builder = new HttpRequestInterceptionBuilder()
+            .ForPost()
+            .ForUrl("https://github.local/login/device/code?client_id=dkd73mfo9ASgjsfnhJD8&scope=public_repo")
+            .WithJsonContent(DeviceCode);
+
+        builder.RegisterWith(Interceptor);
+
+        // Act
+        var actual = await Target.GetDeviceCodeAsync();
+
+        // Assert
+        actual.ShouldNotBeNull();
+        actual.DeviceCode.ShouldBe("3584d83530557fdd1f46af8289938c8ef79f9dc5");
+        actual.ExpiresInSeconds.ShouldBe(900);
+        actual.RefreshIntervalInSeconds.ShouldBe(5);
+        actual.UserCode.ShouldBe("WDJB-MJHT");
+        actual.VerificationUrl.ShouldBe("https://github.local/login/device");
+    }
+
+    [Fact]
     public async Task Can_Get_Access_Token()
     {
         // Arrange
@@ -69,7 +92,7 @@ public class GitHubDeviceTokenServiceTests
 
         int attempts = 0;
 
-        RegisterResponse(() =>
+        RegisterAccessTokenResponse(() =>
         {
             var response = responses[attempts++];
             return JsonSerializer.SerializeToUtf8Bytes(response);
@@ -103,7 +126,7 @@ public class GitHubDeviceTokenServiceTests
 
         int attempts = 0;
 
-        RegisterResponse(() =>
+        RegisterAccessTokenResponse(() =>
         {
             var response = responses[attempts++];
             return JsonSerializer.SerializeToUtf8Bytes(response);
@@ -137,7 +160,7 @@ public class GitHubDeviceTokenServiceTests
 
         int attempts = 0;
 
-        RegisterResponse(() =>
+        RegisterAccessTokenResponse(() =>
         {
             var response = responses[attempts++];
             return JsonSerializer.SerializeToUtf8Bytes(response);
@@ -201,9 +224,9 @@ public class GitHubDeviceTokenServiceTests
     private static object Error(string code) => new { error = code };
 
     private void RegisterResponse(object json)
-        => RegisterResponse(() => JsonSerializer.SerializeToUtf8Bytes(json));
+        => RegisterAccessTokenResponse(() => JsonSerializer.SerializeToUtf8Bytes(json));
 
-    private void RegisterResponse(Func<byte[]> contentFactory)
+    private void RegisterAccessTokenResponse(Func<byte[]> contentFactory)
     {
         var builder = new HttpRequestInterceptionBuilder()
             .ForPost()

--- a/tests/Dashboard.Tests/GitHubDeviceTokenServiceTests.cs
+++ b/tests/Dashboard.Tests/GitHubDeviceTokenServiceTests.cs
@@ -1,0 +1,215 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using JustEat.HttpClientInterception;
+using MartinCostello.Benchmarks.Models;
+using Microsoft.Extensions.Time.Testing;
+
+namespace MartinCostello.Benchmarks;
+
+public class GitHubDeviceTokenServiceTests
+{
+    public GitHubDeviceTokenServiceTests(ITestOutputHelper outputHelper)
+    {
+        TimeProvider = new();
+        Options = new()
+        {
+            GitHubClientId = "dkd73mfo9ASgjsfnhJD8",
+            GitHubTokenUrl = new("https://github.local"),
+            TokenScopes = ["public_repo"],
+        };
+
+        Interceptor = new HttpClientInterceptorOptions().ThrowsOnMissingRegistration();
+        Interceptor.CreateHttpClient();
+
+        var options = Microsoft.Extensions.Options.Options.Create(Options);
+        var storage = new LocalStorage();
+
+        TokenStore = new GitHubTokenStore(
+            storage,
+            storage,
+            options);
+
+        var client = new GitHubClient(Interceptor.CreateHttpClient(), TokenStore, options);
+        Target = new(client, TimeProvider, outputHelper.ToLogger<GitHubDeviceTokenService>());
+    }
+
+    private GitHubDeviceCode DeviceCode { get; } = new()
+    {
+        DeviceCode = "3584d83530557fdd1f46af8289938c8ef79f9dc5",
+        ExpiresInSeconds = 900,
+        RefreshIntervalInSeconds = 5,
+        UserCode = "WDJB-MJHT",
+        VerificationUrl = "https://github.local/login/device",
+    };
+
+    private HttpClientInterceptorOptions Interceptor { get; }
+
+    private DashboardOptions Options { get; }
+
+    private FakeTimeProvider TimeProvider { get; }
+
+    private GitHubTokenStore TokenStore { get; }
+
+    private GitHubDeviceTokenService Target { get; }
+
+    [Fact]
+    public async Task Can_Get_Access_Token()
+    {
+        // Arrange
+        var responses = new[]
+        {
+            Error("authorization_pending"),
+            Error("authorization_pending"),
+            Error("authorization_pending"),
+            Error("authorization_pending"),
+            AccessToken(),
+        };
+
+        int attempts = 0;
+
+        RegisterResponse(() =>
+        {
+            var response = responses[attempts++];
+            return JsonSerializer.SerializeToUtf8Bytes(response);
+        });
+
+        // Act
+        var task = Target.WaitForAccessTokenAsync(DeviceCode);
+
+        while (!task.IsCompleted)
+        {
+            TimeProvider.Advance(TimeSpan.FromSeconds(1));
+        }
+
+        var actual = await task;
+
+        // Assert
+        actual.ShouldBe("not_a_real_token");
+    }
+
+    [Fact]
+    public async Task Cannot_Get_Access_Token_When_Denied()
+    {
+        // Arrange
+        var responses = new[]
+        {
+            Error("authorization_pending"),
+            Error("authorization_pending"),
+            Error("authorization_pending"),
+            Error("access_denied"),
+        };
+
+        int attempts = 0;
+
+        RegisterResponse(() =>
+        {
+            var response = responses[attempts++];
+            return JsonSerializer.SerializeToUtf8Bytes(response);
+        });
+
+        // Act
+        var task = Target.WaitForAccessTokenAsync(DeviceCode);
+
+        while (!task.IsCompleted)
+        {
+            TimeProvider.Advance(TimeSpan.FromSeconds(1));
+        }
+
+        var actual = await task;
+
+        // Assert
+        actual.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Cannot_Get_Access_Token_When_Expired()
+    {
+        // Arrange
+        var responses = new[]
+        {
+            Error("authorization_pending"),
+            Error("authorization_pending"),
+            Error("authorization_pending"),
+            Error("expired_token"),
+        };
+
+        int attempts = 0;
+
+        RegisterResponse(() =>
+        {
+            var response = responses[attempts++];
+            return JsonSerializer.SerializeToUtf8Bytes(response);
+        });
+
+        // Act
+        var task = Target.WaitForAccessTokenAsync(DeviceCode);
+
+        while (!task.IsCompleted)
+        {
+            TimeProvider.Advance(TimeSpan.FromSeconds(1));
+        }
+
+        var actual = await task;
+
+        // Assert
+        actual.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Cannot_Get_Access_Token_When_Timed_Out()
+    {
+        // Arrange
+        RegisterResponse(Error("authorization_pending"));
+
+        // Act
+        var task = Target.WaitForAccessTokenAsync(DeviceCode);
+
+        while (!task.IsCompleted)
+        {
+            TimeProvider.Advance(TimeSpan.FromSeconds(1));
+        }
+
+        var actual = await task;
+
+        // Assert
+        actual.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Cannot_Get_Access_Token_When_Device_Flow_Disabled()
+    {
+        // Arrange
+        RegisterResponse(Error("device_flow_disabled"));
+
+        // Act
+        var actual = await Target.WaitForAccessTokenAsync(DeviceCode);
+
+        // Assert
+        actual.ShouldBeNull();
+    }
+
+    private static object AccessToken() =>
+        new
+        {
+            access_token = "not_a_real_token",
+            token_type = "bearer",
+            scope = "public_repo",
+        };
+
+    private static object Error(string code) => new { error = code };
+
+    private void RegisterResponse(object json)
+        => RegisterResponse(() => JsonSerializer.SerializeToUtf8Bytes(json));
+
+    private void RegisterResponse(Func<byte[]> contentFactory)
+    {
+        var builder = new HttpRequestInterceptionBuilder()
+            .ForPost()
+            .ForUrl($"{Options.GitHubTokenUrl}login/oauth/access_token?client_id=dkd73mfo9ASgjsfnhJD8&device_code={DeviceCode.DeviceCode}&grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code")
+            .WithContent(contentFactory);
+
+        builder.RegisterWith(Interceptor);
+    }
+}

--- a/tests/Dashboard.Tests/GitHubServiceTests.cs
+++ b/tests/Dashboard.Tests/GitHubServiceTests.cs
@@ -1,0 +1,287 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Net;
+using JustEat.HttpClientInterception;
+
+namespace MartinCostello.Benchmarks;
+
+public class GitHubServiceTests
+{
+    public GitHubServiceTests()
+    {
+        Options = new()
+        {
+            BenchmarkFileName = "data.json",
+            GitHubApiUrl = new("https://api.github.local"),
+            GitHubApiVersion = "2022-11-28",
+            GitHubClientId = "dkd73mfo9ASgjsfnhJD8",
+            GitHubServerUrl = new("https://github.local"),
+            Repositories = ["benchmarks-demo", "website"],
+            RepositoryOwner = "martincostello",
+            RepositoryName = "benchmarks",
+            TokenScopes = ["public_repo"],
+        };
+
+        Interceptor = new HttpClientInterceptorOptions().ThrowsOnMissingRegistration();
+        Interceptor.CreateHttpClient();
+
+        var options = Microsoft.Extensions.Options.Options.Create(Options);
+        var storage = new LocalStorage();
+
+        TokenStore = new GitHubTokenStore(
+            storage,
+            storage,
+            options);
+
+        var client = new GitHubClient(Interceptor.CreateHttpClient(), TokenStore, options);
+        Target = new(client, TokenStore, options);
+    }
+
+    private HttpClientInterceptorOptions Interceptor { get; }
+
+    private DashboardOptions Options { get; }
+
+    private GitHubTokenStore TokenStore { get; }
+
+    private GitHubService Target { get; }
+
+    [Fact]
+    public void HasToken_Is_Correct_No_Token()
+    {
+        // Act and Assert
+        Target.HasToken.ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData("", false)]
+    [InlineData(" ", false)]
+    [InlineData("foo", true)]
+    public async Task HasToken_Is_Correct_With_Token(string token, bool expected)
+    {
+        // Arrange
+        await TokenStore.StoreTokenAsync(token);
+
+        // Act and Assert
+        Target.HasToken.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Repositories_Are_Correct()
+    {
+        // Act
+        Target.Repositories.ShouldBe(["benchmarks-demo", "website"]);
+    }
+
+    [Fact]
+    public async Task Can_Load_Benchmarks_Data()
+    {
+        // Assert
+        Target.CurrentRepository.ShouldBeNull();
+
+        Target.Branches.ShouldBe([]);
+        Target.CurrentBranch.ShouldBeNull();
+        Target.BranchUrl().ShouldBe("#");
+
+        Target.CurrentCommit.ShouldBeNull();
+        Target.CommitUrl().ShouldBe("#");
+
+        Target.Benchmarks.ShouldBeNull();
+
+        // Arrange
+        string repository = "website";
+
+        RegisterResponse($"https://api.github.local/repos/{Options.RepositoryOwner}/{repository}", $"{repository}-repo");
+        RegisterResponse($"https://api.github.local/repos/{Options.RepositoryOwner}/{repository}/branches", $"{repository}-branches");
+        RegisterResponse($"https://api.github.local/repos/{Options.RepositoryOwner}/{Options.RepositoryName}/contents/{repository}/data.json?ref=main", $"{repository}-main");
+        RegisterResponse($"https://api.github.local/repos/{Options.RepositoryOwner}/{Options.RepositoryName}/contents/{repository}/data.json?ref=dev", $"{repository}-dev");
+        Interceptor.RegisterGet($"https://api.github.local/repos/{Options.RepositoryOwner}/{Options.RepositoryName}/contents/{repository}/data.json?ref=deleted", string.Empty, System.Net.HttpStatusCode.NotFound);
+
+        // Act
+        await Target.LoadRepositoryAsync(repository);
+
+        // Assert
+        Target.CurrentRepository.ShouldNotBeNull();
+        Target.CurrentRepository.Name.ShouldBe(repository);
+
+        Target.Branches.ShouldBe(["main", "dev"]);
+        Target.CurrentBranch.ShouldBe("main");
+        Target.BranchUrl().ShouldBe("https://github.local/martincostello/website/tree/main");
+
+        Target.CurrentCommit.ShouldBe("349c16ff922077402de4777184582bb04d5d9e77");
+        Target.CommitUrl().ShouldBe("https://github.local/martincostello/website/commits/349c16ff922077402de4777184582bb04d5d9e77");
+
+        Target.Benchmarks.ShouldNotBeNull();
+        Target.Benchmarks.Suites.ShouldContainKey("Website");
+        Target.Benchmarks.Suites["Website"].Count.ShouldBe(24);
+
+        // Arrange
+        var previous = Target.Benchmarks;
+
+        // Act
+        await Target.LoadBenchmarksAsync("dev");
+
+        // Assert
+        Target.CurrentRepository.ShouldNotBeNull();
+        Target.CurrentRepository.Name.ShouldBe(repository);
+
+        Target.Branches.ShouldBe(["main", "dev"]);
+        Target.CurrentBranch.ShouldBe("dev");
+        Target.BranchUrl().ShouldBe("https://github.local/martincostello/website/tree/dev");
+
+        Target.CurrentCommit.ShouldBe("323cbb3a8f1ee38ee935d876297f9e281e8b2c0f");
+        Target.CommitUrl().ShouldBe("https://github.local/martincostello/website/commits/323cbb3a8f1ee38ee935d876297f9e281e8b2c0f");
+
+        Target.Benchmarks.ShouldNotBeNull();
+        Target.Benchmarks.ShouldNotBeSameAs(previous);
+        Target.Benchmarks.Suites.ShouldContainKey("Website");
+        Target.Benchmarks.Suites["Website"].Count.ShouldBe(25);
+
+        // Act
+        await Target.LoadBenchmarksAsync("deleted");
+
+        // Assert
+        Target.CurrentRepository.ShouldNotBeNull();
+        Target.CurrentRepository.Name.ShouldBe(repository);
+
+        Target.Branches.ShouldBe(["main", "dev"]);
+        Target.CurrentBranch.ShouldBe("deleted");
+        Target.BranchUrl().ShouldBe("https://github.local/martincostello/website/tree/deleted");
+
+        Target.CurrentCommit.ShouldBeNull();
+        Target.CommitUrl().ShouldBe("#");
+
+        Target.Benchmarks.ShouldBeNull();
+
+        // Arrange
+        repository = "benchmarks-demo";
+
+        RegisterResponse($"https://api.github.local/repos/{Options.RepositoryOwner}/{repository}", $"{repository}-repo");
+        RegisterResponse($"https://api.github.local/repos/{Options.RepositoryOwner}/{repository}/branches", $"{repository}-branches");
+        RegisterResponse($"https://api.github.local/repos/{Options.RepositoryOwner}/{Options.RepositoryName}/contents/{repository}/data.json?ref=main", $"{repository}-main");
+
+        // Act
+        await Target.LoadRepositoryAsync(repository);
+
+        // Assert
+        Target.CurrentRepository.ShouldNotBeNull();
+        Target.CurrentRepository.Name.ShouldBe(repository);
+
+        Target.Branches.ShouldBe(["main", "dotnet-nightly", "dotnet-vnext"]);
+        Target.CurrentBranch.ShouldBe("main");
+        Target.BranchUrl().ShouldBe("https://github.local/martincostello/benchmarks-demo/tree/main");
+
+        Target.CurrentCommit.ShouldBe("a4ba507a6e549244ec5142e47d65ac7f6abebc32");
+        Target.CommitUrl().ShouldBe("https://github.local/martincostello/benchmarks-demo/commits/a4ba507a6e549244ec5142e47d65ac7f6abebc32");
+
+        Target.Benchmarks.ShouldNotBeNull();
+        Target.Benchmarks.Suites.Count.ShouldBe(4);
+    }
+
+    [Fact]
+    public async Task Can_Sign_In_And_Out()
+    {
+        // Act and Assert
+        Target.CurrentUser.ShouldBeNull();
+        Target.HasToken.ShouldBeFalse();
+        Target.InvalidToken.ShouldBeFalse();
+        Target.ConnectionUrl().ShouldBe("#");
+
+        // Arrange
+        RegisterResponse("https://api.github.local/user", "user-valid-token");
+
+        bool signedIn = false;
+
+        void AssertSignedIn(object? sender, GitHubUserChangedEventArgs args)
+        {
+            sender.ShouldBe(Target);
+            args.ShouldNotBeNull();
+            args.User.ShouldNotBeNull();
+            args.User.Login.ShouldBe("speedy");
+            signedIn = true;
+        }
+
+        Target.OnUserChanged += AssertSignedIn;
+
+        // Act
+        await Target.SignInAsync("foo");
+
+        // Assert
+        signedIn.ShouldBeTrue();
+
+        Target.CurrentUser.ShouldNotBeNull();
+        Target.CurrentUser.Login.ShouldBe("speedy");
+
+        Target.HasToken.ShouldBeTrue();
+        Target.InvalidToken.ShouldBeFalse();
+        Target.ConnectionUrl().ShouldBe("https://github.local/settings/connections/applications/dkd73mfo9ASgjsfnhJD8");
+
+        (await TokenStore.GetTokenAsync()).ShouldBe("foo");
+
+        // Arrange
+        bool signedOut = false;
+
+        void AssertSignedOut(object? sender, GitHubUserChangedEventArgs args)
+        {
+            sender.ShouldBe(Target);
+            args.ShouldNotBeNull();
+            args.User.ShouldBeNull();
+            signedOut = true;
+        }
+
+        Target.OnUserChanged -= AssertSignedIn;
+        Target.OnUserChanged += AssertSignedOut;
+
+        // Act
+        await Target.SignOutAsync();
+
+        // Assert
+        signedOut.ShouldBeTrue();
+
+        Target.CurrentUser.ShouldBeNull();
+        Target.HasToken.ShouldBeFalse();
+        Target.InvalidToken.ShouldBeFalse();
+        Target.ConnectionUrl().ShouldBe("#");
+    }
+
+    [Fact]
+    public async Task Cannot_Sign_In_If_Token_Invalid()
+    {
+        // Act and Assert
+        Target.CurrentUser.ShouldBeNull();
+        Target.HasToken.ShouldBeFalse();
+        Target.InvalidToken.ShouldBeFalse();
+        Target.ConnectionUrl().ShouldBe("#");
+
+        // Arrange
+        RegisterResponse("https://api.github.local/user", "user-invalid-token", HttpStatusCode.NotFound);
+
+        bool signedIn = false;
+
+        void AssertSignedIn(object? sender, GitHubUserChangedEventArgs args)
+            => signedIn = true;
+
+        Target.OnUserChanged += AssertSignedIn;
+
+        // Act
+        await Target.SignInAsync("foo");
+
+        // Assert
+        signedIn.ShouldBeFalse();
+
+        Target.CurrentUser.ShouldBeNull();
+        Target.HasToken.ShouldBeFalse();
+        Target.InvalidToken.ShouldBeTrue();
+        Target.ConnectionUrl().ShouldBe("#");
+    }
+
+    private void RegisterResponse(string url, string name, HttpStatusCode statusCode = HttpStatusCode.OK)
+    {
+        var builder = new HttpRequestInterceptionBuilder()
+            .ForUrl(url)
+            .WithStatus(statusCode)
+            .WithContentStream(() => File.OpenRead(Path.Combine(".", "Responses", $"{name}.json")));
+
+        builder.RegisterWith(Interceptor);
+    }
+}

--- a/tests/Dashboard.Tests/GitHubTokenStoreTests.cs
+++ b/tests/Dashboard.Tests/GitHubTokenStoreTests.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Options;
+
+namespace MartinCostello.Benchmarks;
+
+#pragma warning disable CA1849
+
+public static class GitHubTokenStoreTests
+{
+    [Fact]
+    public static async Task Can_Get_And_Set_Token()
+    {
+        // Arrange
+        var storage = new LocalStorage();
+        var options = Options.Create(new DashboardOptions() { GitHubServerUrl = new("https://github.local") });
+        var target = new GitHubTokenStore(storage, storage, options);
+
+        // Act
+        var actual = target.GetToken();
+
+        // Assert
+        actual.ShouldBeNull();
+
+        // Act
+        actual = await target.GetTokenAsync();
+
+        // Assert
+        actual.ShouldBeNull();
+
+        // Arrange
+        await target.StoreTokenAsync("foo");
+
+        // Assert
+        actual = target.GetToken();
+        actual.ShouldBe("foo");
+
+        actual = await target.GetTokenAsync();
+        actual.ShouldBe("foo");
+
+        // Arrange
+        await target.StoreTokenAsync(string.Empty);
+
+        // Assert
+        actual = target.GetToken();
+        actual.ShouldBeEmpty();
+
+        actual = await target.GetTokenAsync();
+        actual.ShouldBeEmpty();
+    }
+}

--- a/tests/Dashboard.Tests/LocalStorage.cs
+++ b/tests/Dashboard.Tests/LocalStorage.cs
@@ -1,0 +1,102 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using Blazored.LocalStorage;
+
+namespace MartinCostello.Benchmarks;
+
+internal sealed class LocalStorage : ILocalStorageService, ISyncLocalStorageService
+{
+    private readonly Dictionary<string, string?> _storage = [];
+
+#pragma warning disable CS0067
+    public event EventHandler<ChangingEventArgs>? Changing;
+
+    public event EventHandler<ChangedEventArgs>? Changed;
+#pragma warning restore CS0067
+
+    public void Clear() => _storage.Clear();
+
+    public ValueTask ClearAsync(CancellationToken cancellationToken = default)
+    {
+        Clear();
+        return ValueTask.CompletedTask;
+    }
+
+    public bool ContainKey(string key) => _storage.ContainsKey(key);
+
+    public ValueTask<bool> ContainKeyAsync(string key, CancellationToken cancellationToken = default)
+    {
+        var result = ContainKey(key);
+        return ValueTask.FromResult(result);
+    }
+
+    public string? GetItemAsString(string key)
+    {
+        if (!_storage.TryGetValue(key, out var result))
+        {
+            result = null;
+        }
+
+        return result;
+    }
+
+    public ValueTask<string?> GetItemAsStringAsync(string key, CancellationToken cancellationToken = default)
+    {
+        var result = GetItemAsString(key);
+        return ValueTask.FromResult(result);
+    }
+
+    public void SetItemAsString(string key, string data)
+        => _storage[key] = data;
+
+    public ValueTask SetItemAsStringAsync(string key, string data, CancellationToken cancellationToken = default)
+    {
+        SetItemAsString(key, data);
+        return ValueTask.CompletedTask;
+    }
+
+    public T? GetItem<T>(string key)
+    {
+        throw new NotImplementedException();
+    }
+
+    public ValueTask<T?> GetItemAsync<T>(string key, CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+
+    public string? Key(int index)
+        => throw new NotImplementedException();
+
+    public ValueTask<string?> KeyAsync(int index, CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+
+    public IEnumerable<string> Keys()
+        => throw new NotImplementedException();
+
+    public ValueTask<IEnumerable<string>> KeysAsync(CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+
+    public int Length()
+        => throw new NotImplementedException();
+
+    public ValueTask<int> LengthAsync(CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+
+    public void RemoveItem(string key)
+        => throw new NotImplementedException();
+
+    public ValueTask RemoveItemAsync(string key, CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+
+    public void RemoveItems(IEnumerable<string> keys)
+        => throw new NotImplementedException();
+
+    public ValueTask RemoveItemsAsync(IEnumerable<string> keys, CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+
+    public void SetItem<T>(string key, T data)
+        => throw new NotImplementedException();
+
+    public ValueTask SetItemAsync<T>(string key, T data, CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+}

--- a/tests/Dashboard.Tests/PageModels/AppPage.cs
+++ b/tests/Dashboard.Tests/PageModels/AppPage.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.Playwright;
 
-namespace MartinCostello.Benchmarks.Pages;
+namespace MartinCostello.Benchmarks.PageModels;
 
 public abstract class AppPage(IPage page)
 {

--- a/tests/Dashboard.Tests/PageModels/HomePage.cs
+++ b/tests/Dashboard.Tests/PageModels/HomePage.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.Playwright;
 
-namespace MartinCostello.Benchmarks.Pages;
+namespace MartinCostello.Benchmarks.PageModels;
 
 public class HomePage(IPage page) : AppPage(page)
 {

--- a/tests/Dashboard.Tests/PageModels/TokenPage.cs
+++ b/tests/Dashboard.Tests/PageModels/TokenPage.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.Playwright;
 
-namespace MartinCostello.Benchmarks.Pages;
+namespace MartinCostello.Benchmarks.PageModels;
 
 public sealed class TokenPage(IPage page) : AppPage(page)
 {

--- a/tests/Dashboard.Tests/Pages/HomeTests.cs
+++ b/tests/Dashboard.Tests/Pages/HomeTests.cs
@@ -76,40 +76,40 @@ public static class HomeTests
             new()
             {
                 Timestamp = new DateTimeOffset(2024, 08, 31, 00, 05, 00, TimeSpan.Zero),
-                Commit = new() { Sha = "abc" },
+                Commit = CreateCommit("abc"),
                 Benchmarks =
                 [
-                    new() { Name = "A", Value = 1 },
+                    new() { Name = "A", Value = 1, Range = "± 0.1" },
                 ],
             },
             new()
             {
                 Timestamp = new DateTimeOffset(2024, 09, 01, 00, 05, 00, TimeSpan.Zero),
-                Commit = new() { Sha = "def" },
+                Commit = CreateCommit("def"),
                 Benchmarks =
                 [
                     new() { Name = "A", Value = 2 },
-                    new() { Name = "B", Value = 2678 },
+                    new() { Name = "B", Value = 2678, Range = "± 17" },
                 ],
             },
             new()
             {
                 Timestamp = new DateTimeOffset(2024, 09, 01, 00, 05, 15, TimeSpan.Zero),
-                Commit = new() { Sha = "def" },
+                Commit = CreateCommit("def"),
                 Benchmarks =
                 [
                     new() { Name = "A", Value = 3 },
-                    new() { Name = "B", Value = 2497 },
+                    new() { Name = "B", Value = 2497, Range = "± 14.3" },
                 ],
             },
             new()
             {
                 Timestamp = new DateTimeOffset(2024, 09, 02, 00, 05, 00, TimeSpan.Zero),
-                Commit = new() { Sha = "123" },
+                Commit = CreateCommit("123"),
                 Benchmarks =
                 [
                     new() { Name = "A", Value = 4 },
-                    new() { Name = "B", Value = 2642 },
+                    new() { Name = "B", Value = 2642, Range = "± 26.7" },
                 ],
             },
         };
@@ -139,5 +139,18 @@ public static class HomeTests
         values[0].Result.Unit.ShouldBe("µs");
         values[1].Result.Value.ShouldBe(2.642);
         values[1].Result.Unit.ShouldBe("µs");
+    }
+
+    private static GitCommit CreateCommit(string sha)
+    {
+        return new GitCommit()
+        {
+            Author = new() { UserName = "octocat" },
+            Committer = new() { UserName = "webflow" },
+            LastUpdated = DateTime.UtcNow,
+            Message = "Update code",
+            Sha = sha,
+            Url = $"https://github.local/octocat/repository/commits/{sha}",
+        };
     }
 }

--- a/tests/Dashboard.Tests/Pages/TokenTests.cs
+++ b/tests/Dashboard.Tests/Pages/TokenTests.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using AngleSharp.Html.Dom;
+using Bunit;
+using JustEat.HttpClientInterception;
+using MartinCostello.Benchmarks.Models;
+
+namespace MartinCostello.Benchmarks.Pages;
+
+public class TokenTests : DashboardTestContext
+{
+    [Fact]
+    public void Page_Renders()
+    {
+        // Arrange
+        var deviceCode = new GitHubDeviceCode()
+        {
+            DeviceCode = "3584d83530557fdd1f46af8289938c8ef79f9dc5",
+            ExpiresInSeconds = 900,
+            RefreshIntervalInSeconds = 5,
+            UserCode = "WDJB-MJHT",
+            VerificationUrl = "https://github.local/login/device",
+        };
+
+        var builder = new HttpRequestInterceptionBuilder()
+            .ForPost()
+            .ForUrl("https://github.local/login/device/code?client_id=dkd73mfo9ASgjsfnhJD8&scope=public_repo")
+            .WithJsonContent(deviceCode);
+
+        builder.RegisterWith(Interceptor);
+
+        JSInterop.SetupVoid("configureClipboard", (_) => true);
+
+        // Act
+        var actual = RenderComponent<Token>();
+
+        // Assert
+        actual.WaitForAssertion(
+            () =>
+            {
+                var userCode = actual.Find("[id='user-code']");
+
+                var input = userCode as IHtmlInputElement;
+                input.ShouldNotBeNull();
+                input.Value.ShouldBe("WDJB-MJHT");
+
+                actual.Find("[id='authorize']").TextContent.ShouldContain("Authorize");
+            },
+            TimeSpan.FromSeconds(2));
+    }
+
+    [Fact]
+    public void Page_Renders_If_Token_Cannot_Be_Generated()
+    {
+        // Arrange
+        var builder = new HttpRequestInterceptionBuilder()
+            .ForPost()
+            .ForUrl("https://github.local/login/device/code?client_id=dkd73mfo9ASgjsfnhJD8&scope=public_repo")
+            .WithStatus(404);
+
+        builder.RegisterWith(Interceptor);
+
+        JSInterop.SetupVoid("configureClipboard", (_) => true);
+
+        // Act
+        var actual = RenderComponent<Token>();
+
+        // Assert
+        actual.WaitForAssertion(
+            () => actual.Find("[id='generation-failed']"),
+            TimeSpan.FromSeconds(2));
+    }
+}

--- a/tests/Dashboard.Tests/Responses/website-dev.json
+++ b/tests/Dashboard.Tests/Responses/website-dev.json
@@ -1121,6 +1121,51 @@
             "bytesAllocated": 59275
           }
         ]
+      },
+      {
+        "commit": {
+          "author": {
+            "username": "dependabot[bot]"
+          },
+          "committer": {
+            "username": "web-flow"
+          },
+          "sha": "323cbb3a8f1ee38ee935d876297f9e281e8b2c0f",
+          "message": "Bump the typescript-eslint group in /src/Website with 2 updates (#2200)\n\nBumps the typescript-eslint group in /src/Website with 2 updates: [@typescript-eslint/eslint-plugin](https://github.com/typescript-eslint/typescript-eslint/tree/HEAD/packages/eslint-plugin) and [@typescript-eslint/parser](https://github.com/typescript-eslint/typescript-eslint/tree/HEAD/packages/parser).\n\n\nUpdates `@typescript-eslint/eslint-plugin` from 8.3.0 to 8.4.0\n- [Release notes](https://github.com/typescript-eslint/typescript-eslint/releases)\n- [Changelog](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/CHANGELOG.md)\n- [Commits](https://github.com/typescript-eslint/typescript-eslint/commits/v8.4.0/packages/eslint-plugin)\n\nUpdates `@typescript-eslint/parser` from 8.3.0 to 8.4.0\n- [Release notes](https://github.com/typescript-eslint/typescript-eslint/releases)\n- [Changelog](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/parser/CHANGELOG.md)\n- [Commits](https://github.com/typescript-eslint/typescript-eslint/commits/v8.4.0/packages/parser)\n\n---\nupdated-dependencies:\n- dependency-name: \"@typescript-eslint/eslint-plugin\"\n  dependency-type: direct:development\n  update-type: version-update:semver-minor\n  dependency-group: typescript-eslint\n- dependency-name: \"@typescript-eslint/parser\"\n  dependency-type: direct:development\n  update-type: version-update:semver-minor\n  dependency-group: typescript-eslint\n...\n\nSigned-off-by: dependabot[bot] <support@github.com>\nCo-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>",
+          "timestamp": "2024-09-03T04:58:04Z",
+          "url": "https://github.com/martincostello/website/commit/323cbb3a8f1ee38ee935d876297f9e281e8b2c0f"
+        },
+        "date": 1725339706915,
+        "benches": [
+          {
+            "name": "MartinCostello.Website.Benchmarks.WebsiteBenchmarks.Root",
+            "value": 362616.41822916665,
+            "unit": "ns",
+            "range": "± 1231.408125705579",
+            "bytesAllocated": 48387
+          },
+          {
+            "name": "MartinCostello.Website.Benchmarks.WebsiteBenchmarks.About",
+            "value": 368072.05345052085,
+            "unit": "ns",
+            "range": "± 3498.528803888654",
+            "bytesAllocated": 51332
+          },
+          {
+            "name": "MartinCostello.Website.Benchmarks.WebsiteBenchmarks.Projects",
+            "value": 428421.533203125,
+            "unit": "ns",
+            "range": "± 5894.043999510876",
+            "bytesAllocated": 65218
+          },
+          {
+            "name": "MartinCostello.Website.Benchmarks.WebsiteBenchmarks.Tools",
+            "value": 402068.78357872594,
+            "unit": "ns",
+            "range": "± 4054.4578693451845",
+            "bytesAllocated": 59268
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
- Add unit tests for various classes.
- Add code coverage.
- Refactor method to make screenshots to be easier to use.
- Move page models to their own namespace away from Pages.
- Remove duplicate base class declaration.
- Clear any existing `Accept` header value before adding a new one.
- Pass `TimeProvider` to `Task.Delay()`.
- Remove hard-coded prefix for metric ranges.
