### PR TITLE
CodeQL and Pages fixes

### DIFF
--- a/src/Dashboard/wwwroot/404.html
+++ b/src/Dashboard/wwwroot/404.html
@@ -2,14 +2,6 @@
 <html lang="en-gb">
 <head prefix="og:http://ogp.me/ns#">
   <base href="/" />
-  <!--
-  <script>
-    if (window.location.pathname.length > 1) {
-      const base = document.querySelector('base');
-      base.href = window.location.pathname;
-    }
-  </script>
-  -->
   <title>Benchmarks - .NET Benchmarks</title>
   <meta http-equiv="cache-control" content="no-cache, no-store" />
   <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -86,7 +78,19 @@
   </script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.3/flatly/bootstrap.min.css" integrity="sha512-qoT4KwnRpAQ9uczPsw7GunsNmhRnYwSlE2KRCUPRQHSkDuLulCtDXuC2P/P6oqr3M5hoGagUG9pgHDPkD2zCDA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css" integrity="sha512-Kc323vGBEqzTmouAECnVceyQqyqdsSiqLQISBL29aUW4U/M7pSPA/gEUZQqv1cwx4OnYxTxve5UMg5GT6L4JJg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-  <link rel="stylesheet" href="app.css" />
+  <script type="text/javascript">
+    if (window.location.pathname.length > 1) {
+      const base = document.querySelector('base');
+      base.href = window.location.pathname;
+    }
+    const links = ['app.css'];
+    for (const href of links) {
+      const link = document.createElement('link');
+      link.setAttribute('href', href);
+      link.setAttribute('rel', 'stylesheet');
+      document.head.appendChild(link);
+    }
+  </script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.3/js/bootstrap.bundle.min.js" integrity="sha512-7Pi/otdlbbCR+LnW+F7PwFcSDJOuUJB3OxtEHbg4vSMvzvJjde4Po1v4BR9Gdc9aXNUNFVUY+SK51wWT8WF0Gg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 </head>
 <body id="app">

--- a/src/Dashboard/wwwroot/index.html
+++ b/src/Dashboard/wwwroot/index.html
@@ -2,14 +2,6 @@
 <html lang="en-gb">
 <head prefix="og:http://ogp.me/ns#">
   <base href="/" />
-  <!--
-  <script>
-    if (window.location.pathname.length > 1) {
-      const base = document.querySelector('base');
-      base.href = window.location.pathname;
-    }
-  </script>
-  -->
   <title>Benchmarks - .NET Benchmarks</title>
   <meta http-equiv="cache-control" content="no-cache, no-store" />
   <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -86,7 +78,19 @@
   </script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.3/flatly/bootstrap.min.css" integrity="sha512-qoT4KwnRpAQ9uczPsw7GunsNmhRnYwSlE2KRCUPRQHSkDuLulCtDXuC2P/P6oqr3M5hoGagUG9pgHDPkD2zCDA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css" integrity="sha512-Kc323vGBEqzTmouAECnVceyQqyqdsSiqLQISBL29aUW4U/M7pSPA/gEUZQqv1cwx4OnYxTxve5UMg5GT6L4JJg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-  <link rel="stylesheet" href="app.css" />
+  <script type="text/javascript">
+    if (window.location.pathname.length > 1) {
+      const base = document.querySelector('base');
+      base.href = window.location.pathname;
+    }
+    const links = ['app.css'];
+    for (const href of links) {
+      const link = document.createElement('link');
+      link.setAttribute('href', href);
+      link.setAttribute('rel', 'stylesheet');
+      document.head.appendChild(link);
+    }
+  </script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.3/js/bootstrap.bundle.min.js" integrity="sha512-7Pi/otdlbbCR+LnW+F7PwFcSDJOuUJB3OxtEHbg4vSMvzvJjde4Po1v4BR9Gdc9aXNUNFVUY+SK51wWT8WF0Gg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.11/clipboard.min.js" integrity="sha512-7O5pXpc0oCRrxk8RUfDYFgn0nO1t+jLuIOQdOMRp4APB7uZ4vSjspzp5y6YDtDs4VzUSTbWzBFZ/LKJhnyFOKw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/plotly.js/2.35.0/plotly-basic.min.js" integrity="sha512-W1yclMQz4hEhwe6cPzwYRL6dAJRz0CJblrA0uY4nzjr5N5ZlmZ9WMpGaubciKazXswt4YFhI9D0G0CVjvsKKfw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
@@ -113,7 +117,13 @@
       <a class="dismiss">🗙</a>
     </div>
   </main>
-  <script src="app.js"></script>
-  <script src="_framework/blazor.webassembly.js"></script>
+  <script type="text/javascript">
+    const scripts = ['app.js', '_framework/blazor.webassembly.js'];
+    for (const src of scripts) {
+      const script = document.createElement('script');
+      script.setAttribute('src', src);
+      document.body.appendChild(script);
+    }
+  </script>
 </body>
 </html>

--- a/tests/Dashboard.Tests/Pages/TokenTests.cs
+++ b/tests/Dashboard.Tests/Pages/TokenTests.cs
@@ -36,7 +36,7 @@ public class TokenTests : DashboardTestContext
             {
                 var userCode = actual.Find("[id='user-code']");
 
-                var input = userCode as IHtmlInputElement;
+                var input = userCode.ShouldBeAssignableTo<IHtmlInputElement>();
                 input.ShouldNotBeNull();
                 input.Value.ShouldBe(deviceCode.UserCode);
 


### PR DESCRIPTION
- Use `ShouldBeAssignableTo<T>()` instead of `as` to avoid CodeQL warning.
- Avoid 404s in GitHub Pages without a custom domain by dynamically inserting the local CSS and JavaScript tags after `base` is updated.