### PR TITLE
Add copy-to-clipboard for charts

### DIFF
--- a/src/Dashboard/Components/Benchmark.razor
+++ b/src/Dashboard/Components/Benchmark.razor
@@ -1,9 +1,23 @@
 <div class="benchmark-chart-container col" id="@(Id)">
     <div class="benchmark-chart" id="@(ChartId)" name="@(Name)" />
-    <button class="btn btn-dark btn-small float-end download-chart"
-            id="@(ChartId)-download"
-            title="Download this chart as a @(Options.Value.ImageFormat) file">
-        <Icon Name="@(Icons.ChartLine)" FixedWidth="true" />
-        <Icon Name="@(Icons.FileArrowDown)" FixedWidth="true" />
-    </button>
+    <div class="btn-toolbar float-end" role="toolbar" aria-label="Chart options">
+        <div class="btn-group me-2" role="group" aria-label="Copy">
+            <button class="btn btn-dark btn-small copy-chart"
+                    id="@(ChartId)-copy"
+                    title="Copy this chart to the clipboard as a @(Options.Value.ImageFormat)"
+                    type="button">
+                <Icon Name="@(Icons.ChartLine)" FixedWidth="true" />
+                <Icon Name="@(Icons.Clipboard)" FixedWidth="true" />
+            </button>
+        </div>
+        <div class="btn-group" role="group" aria-label="Download chart">
+            <button class="btn btn-dark btn-small download-chart"
+                    id="@(ChartId)-download"
+                    title="Download this chart as a @(Options.Value.ImageFormat) file"
+                    type="button">
+                <Icon Name="@(Icons.ChartLine)" FixedWidth="true" />
+                <Icon Name="@(Icons.FileArrowDown)" FixedWidth="true" />
+            </button>
+        </div>
+    </div>
 </div>

--- a/src/Dashboard/wwwroot/app.js
+++ b/src/Dashboard/wwwroot/app.js
@@ -320,20 +320,37 @@ window.renderChart = (chartId, configString) => {
     dragLayer.style.cursor = 'default';
   });
 
+  const format = config.imageFormat;
+
+  const copyButton = document.getElementById(`${chartId}-copy`);
+  if ('ClipboardItem' in window && ClipboardItem.supports(`image/${format}`)) {
+    copyButton.addEventListener('click', async () => {
+      const dataUrl = await Plotly.toImage(chart, {
+        format,
+      });
+      const data = await fetch(dataUrl);
+      const blob = await data.blob();
+      await navigator.clipboard.write([
+        new ClipboardItem({
+          [blob.type]: blob
+        })
+      ]);
+    });
+  } else {
+    copyButton.classList.add('disable');
+    copyButton.disabled = true;
+  }
+
   const saveButton = document.getElementById(`${chartId}-download`);
-  saveButton.addEventListener('click', async () => {
-    const format = config.imageFormat;
-    let fileName = config.name;
+  saveButton.addEventListener('click', () => {
+    let filename = config.name;
     for (const toReplace of [' ', '#', ':', ';', '/', '\\']) {
-      fileName = fileName.replace(toReplace, '_');
+      filename = filename.replace(toReplace, '_');
     }
-    fileName = `${fileName}.${format}`;
-    const dataUrl = await Plotly.toImage(chart, {
+    filename = `${filename}.${format}`;
+    Plotly.downloadImage(chart, {
+      filename,
       format,
     });
-    const link = document.createElement('a');
-    link.href = dataUrl;
-    link.download = fileName;
-    link.click();
   });
 };


### PR DESCRIPTION
- Add a button to copy a chart image to the clipboard.
- Remove custom code for downloading images and use `Plotly.downloadImage()` instead.
