### PR TITLE
Change condition

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,7 +36,7 @@
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <VersionPrefix>1.0.0</VersionPrefix>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(GITHUB_ACTIONS)' != '' AND '$(GITHUB_EVENT_NAME)' != 'dynamic' ">
+  <PropertyGroup Condition=" '$(GITHUB_ACTIONS)' != '' AND '$(DEPENDABOT_JOB_ID)' == '' ">
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(GITHUB_HEAD_REF)' == '' ">beta.$(GITHUB_RUN_NUMBER)</VersionSuffix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(GITHUB_HEAD_REF)' != '' ">pr.$(GITHUB_REF_NAME.Replace('/merge', '')).$(GITHUB_RUN_NUMBER)</VersionSuffix>
     <VersionPrefix Condition=" $(GITHUB_REF.StartsWith(`refs/tags/v`)) ">$(GITHUB_REF.Replace('refs/tags/v', ''))</VersionPrefix>


### PR DESCRIPTION
The event name isn't passed through to the container that does updates, so instead check for [`DEPENDABOT_JOB_ID`](https://github.com/github/dependabot-action/blob/f7ebd868254a0fdf9f653eea95637dc6761e976f/src/updater-builder.ts#L40-L58).
