### PR TITLE
Remove MSBUILDTERMINALLOGGER

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -7,10 +7,6 @@ param(
     [Parameter(Mandatory = $false)][switch] $SkipTests
 )
 
-if ($null -eq ${env:MSBUILDTERMINALLOGGER}) {
-  ${env:MSBUILDTERMINALLOGGER} = "auto"
-}
-
 $ErrorActionPreference = "Stop"
 $InformationPreference = "Continue"
 $ProgressPreference = "SilentlyContinue"


### PR DESCRIPTION
Remove redundant usage of `MSBUILDTERMINALLOGGER`.
