### PR TITLE
Handle broken benchmarks

### DIFF
--- a/src/Dashboard/AppJsonSerializerContext.cs
+++ b/src/Dashboard/AppJsonSerializerContext.cs
@@ -14,5 +14,8 @@ namespace MartinCostello.Benchmarks;
 [JsonSerializable(typeof(GitHubDeviceCode))]
 [JsonSerializable(typeof(GitHubRepository))]
 [JsonSerializable(typeof(GitHubUser))]
-[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, WriteIndented = true)]
+[JsonSourceGenerationOptions(
+    NumberHandling = JsonNumberHandling.AllowNamedFloatingPointLiterals | JsonNumberHandling.AllowReadingFromString,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    WriteIndented = true)]
 public sealed partial class AppJsonSerializerContext : JsonSerializerContext;

--- a/src/Dashboard/Components/Benchmark.razor.cs
+++ b/src/Dashboard/Components/Benchmark.razor.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using MartinCostello.Benchmarks.Models;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
@@ -9,6 +11,12 @@ namespace MartinCostello.Benchmarks.Components;
 
 public partial class Benchmark
 {
+    private static readonly JsonSerializerOptions SerializationOptions = new(JsonSerializerDefaults.Web)
+    {
+        NumberHandling = JsonNumberHandling.AllowNamedFloatingPointLiterals | JsonNumberHandling.AllowReadingFromString,
+        PropertyNameCaseInsensitive = false,
+    };
+
     /// <summary>
     /// Gets the benchmark name.
     /// </summary>
@@ -54,19 +62,21 @@ public partial class Benchmark
             timeColor = "#178600";
         }
 
-        var options = System.Text.Json.JsonSerializer.Serialize(new
-        {
-            colors = new
+        var options = System.Text.Json.JsonSerializer.Serialize(
+            new
             {
-                memory = memoryColor,
-                time = timeColor,
+                colors = new
+                {
+                    memory = memoryColor,
+                    time = timeColor,
+                },
+                dataset = Items,
+                errorBars = current.ErrorBars,
+                imageFormat = current.ImageFormat,
+                name = Name,
+                suiteName = Suite,
             },
-            dataset = Items,
-            errorBars = current.ErrorBars,
-            imageFormat = current.ImageFormat,
-            name = Name,
-            suiteName = Suite,
-        });
+            SerializationOptions);
 
         await JS.InvokeVoidAsync("renderChart", [ChartId, options]);
 

--- a/src/Dashboard/wwwroot/app.js
+++ b/src/Dashboard/wwwroot/app.js
@@ -164,7 +164,7 @@ window.renderChart = (chartId, configString) => {
 
   const mapTimeText = (item) => {
     const { range, unit } = item.result;
-    let label = `${item.result.value.toFixed(rounding)}${unit}`;
+    let label = item.result.value === 'NaN' ? NaN : `${item.result.value.toFixed(rounding)}${unit}`;
     if (range) {
       const prefix = range.slice(0, 2);
       const rangeValue = parseFloat(range.slice(2)).toPrecision(precision);
@@ -231,7 +231,7 @@ window.renderChart = (chartId, configString) => {
 
   if (config.errorBars === true) {
     time.error_y = {
-      array: dataset.map((p) => parseFloat(p.result.range.slice(2))),
+      array: dataset.map((p) => parseFloat(p.result.range?.slice(2) ?? 'NaN')),
       type: 'data',
     };
   }


### PR DESCRIPTION
Handle `"NaN"` as a value in the benchmark data if a benchmark run fails.

See https://github.com/martincostello/benchmarkdotnet-results-publisher/pull/266.
