### PR TITLE
Remove dependabot reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,6 @@ updates:
     interval: daily
     time: "05:30"
     timezone: Europe/London
-  reviewers:
-    - "martincostello"
 - package-ecosystem: nuget
   directory: "/"
   groups:
@@ -19,6 +17,4 @@ updates:
     interval: daily
     time: "05:30"
     timezone: Europe/London
-  reviewers:
-    - "martincostello"
   open-pull-requests-limit: 99


### PR DESCRIPTION
Remove dependabot reviewers as the option is deprecated.

<!--

Summarise the changes this Pull Request makes.

Please include a reference to a GitHub issue if appropriate.

-->
