### PR TITLE
Specify RunContinuationsAsynchronously

### DIFF
--- a/tests/Dashboard.Tests/AppLauncher.cs
+++ b/tests/Dashboard.Tests/AppLauncher.cs
@@ -36,7 +36,7 @@ internal static class AppLauncher
             WorkingDirectory = path,
         };
 
-        var completionSource = new TaskCompletionSource();
+        var completionSource = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         using var tokenSource = new CancellationTokenSource(timeout);
 
         var server = Process.Start(startInfo);

--- a/tests/Dashboard.Tests/DashboardTests.cs
+++ b/tests/Dashboard.Tests/DashboardTests.cs
@@ -69,8 +69,8 @@ public class DashboardTests(
             await page.GotoAsync(fixture.ServerAddress);
             await page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
 
-            var cancelled = new TaskCompletionSource<string>();
-            var authorized = new TaskCompletionSource<string>();
+            var cancelled = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var authorized = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             await ConfigureMocksAsync(page, cancelled, authorized);
 


### PR DESCRIPTION
Specify `TaskCreationOptions.RunContinuationsAsynchronously` when creating `TaskCompletionSource<T>`.
