### PR TITLE
Fix deployed version number

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,5 +14,6 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionSuffix Condition=" '$(GitHubBranchName)' == 'main' "></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,6 +14,6 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <VersionSuffix Condition=" '$(GitHubBranchName)' == 'main' "></VersionSuffix>
+    <VersionSuffix Condition=" '$(GITHUB_REF_NAME)' == 'main' "></VersionSuffix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Do not include a version suffix when building from `main`.
