### PR TITLE
Stabilize version for deployment

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,6 +12,7 @@
     <Copyright>Martin Costello (c) $([System.DateTime]::Now.ToString(yyyy))</Copyright>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <StabilizeVersion Condition=" '$(GITHUB_REF_NAME)' == 'main' ">true</StabilizeVersion>
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <VersionPrefix>1.0.0</VersionPrefix>
   </PropertyGroup>


### PR DESCRIPTION
Use a stable version number when deploying from `main`.
