### PR TITLE
Bump Magick.NET-Q16-AnyCPU

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,9 +9,9 @@
     <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageVersion Include="Humanizer" Version="2.14.1" />
-    <PackageVersion Include="Magick.NET-Q16-AnyCPU" Version="14.8.0" />
     <PackageVersion Include="JunitXml.TestLogger" Version="6.1.0" />
     <PackageVersion Include="JustEat.HttpClientInterception" Version="5.1.2" />
+    <PackageVersion Include="Magick.NET-Q16-AnyCPU" Version="14.8.0" />
     <PackageVersion Include="MartinCostello.Logging.XUnit.v3" Version="0.6.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.8" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,6 +9,7 @@
     <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageVersion Include="Humanizer" Version="2.14.1" />
+    <PackageVersion Include="Magick.NET-Q16-AnyCPU" Version="14.8.0" />
     <PackageVersion Include="JunitXml.TestLogger" Version="6.1.0" />
     <PackageVersion Include="JustEat.HttpClientInterception" Version="5.1.2" />
     <PackageVersion Include="MartinCostello.Logging.XUnit.v3" Version="0.6.0" />


### PR DESCRIPTION
Bump Magick.NET-Q16-AnyCPU to 14.8.0 to resolve:
- https://github.com/martincostello/benchmarks-dashboard/security/dependabot/2
- https://github.com/martincostello/benchmarks-dashboard/security/dependabot/3
- https://github.com/martincostello/benchmarks-dashboard/security/dependabot/4
