### PR TITLE
Dark mode follow-ups

### DIFF
--- a/src/Dashboard/wwwroot/404.html
+++ b/src/Dashboard/wwwroot/404.html
@@ -76,24 +76,8 @@
       top.location = self.location;
     }
   </script>
-  <link
-    id="theme-light"
-    rel="stylesheet"
-    href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.8/flatly/bootstrap.min.css"
-    integrity="sha512-6cPfXE7P+s3gLoNVw8XfKNI3nc0kKcDIhZzlFp81ZLRcueIq2ayKiHcT9YT7Z+q0+61MKhvVaSaV5PmG7jEsKA=="
-    crossorigin="anonymous"
-    referrerpolicy="no-referrer"
-    media="(prefers-color-scheme: light)"
-  />
-  <link
-    id="theme-dark"
-    rel="stylesheet"
-    href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.8/darkly/bootstrap.min.css"
-    integrity="sha512-+uC0Ar9AG4/j/iF0Ug22TO9D17MAbD94K7J8h17EzXzN3D5kcOpYQdF4OuiLraHSibCVhz4DIcqwsDboRMVStg=="
-    crossorigin="anonymous"
-    referrerpolicy="no-referrer"
-    media="(prefers-color-scheme: dark)"
-  />
+  <link id="theme-light" rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.8/flatly/bootstrap.min.css" integrity="sha512-6cPfXE7P+s3gLoNVw8XfKNI3nc0kKcDIhZzlFp81ZLRcueIq2ayKiHcT9YT7Z+q0+61MKhvVaSaV5PmG7jEsKA==" crossorigin="anonymous" referrerpolicy="no-referrer" media="(prefers-color-scheme: light)" />
+  <link id="theme-dark" rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.8/darkly/bootstrap.min.css" integrity="sha512-+uC0Ar9AG4/j/iF0Ug22TO9D17MAbD94K7J8h17EzXzN3D5kcOpYQdF4OuiLraHSibCVhz4DIcqwsDboRMVStg==" crossorigin="anonymous" referrerpolicy="no-referrer" media="(prefers-color-scheme: dark)" />
   <script src="theme-switch.js"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css" integrity="sha512-2SwdPD6INVrV/lHTZbO2nodKhrnDdJK9/kg2XD1r9uGqPo1cUbujc+IYdlYdEErWNu69gVcYgdxlmVmzTWnetw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <script type="text/javascript">

--- a/src/Dashboard/wwwroot/app.css
+++ b/src/Dashboard/wwwroot/app.css
@@ -200,13 +200,15 @@ text.gtitle > a {
   color: white;
 }
 
+:root[data-bs-theme='dark'] .form-control,
 :root[data-bs-theme='dark'] .form-select {
   background-color: var(--bs-secondary-bg) !important;
-  color: var(--bs-secondary-color) !important;
   border-color: var(--bs-border-color) !important;
+  color: var(--bs-secondary-color) !important;
 }
 
-:root[data-bs-theme='dark'] .form-select:focus {
+:root[data-bs-theme='dark'] .form-control:focus,
+:root[data-bs-theme='dark'] .form-select:focus{
   background-color: var(--bs-body-bg) !important;
   color: var(--bs-body-color) !important;
 }

--- a/src/Dashboard/wwwroot/app.js
+++ b/src/Dashboard/wwwroot/app.js
@@ -5,13 +5,15 @@ window.toggleTheme = () => {
   const oldBodyColor = getComputedStyle(document.body).backgroundColor;
   window._setBenchmarkTheme(newTheme);
 
+  let depth = 0;
+  const maxDepth = 32;
+
   const waitForThemeChange = () => {
     const newBodyColor = getComputedStyle(document.body).backgroundColor;
     // Only refresh charts if the body color actually changed
     if (oldBodyColor !== newBodyColor) {
       window.refreshChartThemes();
-    }
-    else {
+    } else if (depth++ < maxDepth) {
       requestAnimationFrame(waitForThemeChange);
     }
   }
@@ -117,28 +119,30 @@ window.configureDataDownload = (json, fileName) => {
   }
 };
 
-function getThemeStyles() {
+const getThemeStyles = () => {
   const root = document.documentElement;
   const styles = getComputedStyle(root);
-  const theme = root.getAttribute('data-bs-theme');
   const fontColor = styles.getPropertyValue('--bs-body-color').trim();
   const hoverColor = styles.getPropertyValue('--plot-hover-color').trim();
   const hoverBg = styles.getPropertyValue('--plot-hover-background-color').trim();
   const bgColor = styles.getPropertyValue('--bs-body-bg').trim();
 
   return { fontColor, bgColor, hoverColor, hoverBg };
-}
+};
 
-function applyThemeToLayout(layout) {
+const applyThemeToLayout = (layout) => {
   const { fontColor, bgColor } = getThemeStyles();
+  layout.font.color = fontColor;
   layout.paper_bgcolor = bgColor;
   layout.plot_bgcolor = bgColor;
-  layout.font.color = fontColor;
-  layout.xaxis.color = fontColor;
-  layout.yaxis.color = fontColor;
   layout.title.font = (layout.title.font || {});
   layout.title.font.color = fontColor;
-}
+  layout.xaxis.color = fontColor;
+  layout.yaxis.color = fontColor;
+  if (layout.yaxis2) {
+    layout.yaxis2.color = fontColor;
+  }
+};
 
 window.renderChart = (chartId, configString) => {
   const config = JSON.parse(configString);
@@ -244,14 +248,14 @@ window.renderChart = (chartId, configString) => {
   };
 
   const hovertemplate =
-    "<b>%{text}</b>" +
+    '<b>%{text}</b>' +
     newline +
     newline +
-    "%{x}" +
+    '%{x}' +
     newline +
     newline +
-    "%{customdata}" +
-    "<extra></extra>";
+    '%{customdata}' +
+    '<extra></extra>';
 
   const time = {
     connectgaps: true,
@@ -323,6 +327,7 @@ window.renderChart = (chartId, configString) => {
     data.push(memory);
 
     layout.yaxis2 = {
+      color: layout.font.color,
       fixedrange: true,
       minallowed: 0,
       overlaying: 'y',
@@ -412,13 +417,13 @@ window.refreshChartThemes = () => {
   document.querySelectorAll('.js-plotly-plot').forEach((element) => {
     try {
       Plotly.relayout(element, {
+        'font.color': fontColor,
         'paper_bgcolor': bgColor,
         'plot_bgcolor': bgColor,
-        'font.color': fontColor,
+        'title.font.color': fontColor,
         'xaxis.color': fontColor,
         'yaxis.color': fontColor,
         'yaxis2.color': fontColor,
-        'title.font.color': fontColor,
       });
     } catch (err) {
       console.error('Failed to relayout chart for theme refresh.', err);

--- a/src/Dashboard/wwwroot/index.html
+++ b/src/Dashboard/wwwroot/index.html
@@ -76,24 +76,8 @@
       top.location = self.location;
     }
   </script>
-  <link
-    id="theme-light"
-    rel="stylesheet"
-    href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.8/flatly/bootstrap.min.css"
-    integrity="sha512-6cPfXE7P+s3gLoNVw8XfKNI3nc0kKcDIhZzlFp81ZLRcueIq2ayKiHcT9YT7Z+q0+61MKhvVaSaV5PmG7jEsKA=="
-    crossorigin="anonymous"
-    referrerpolicy="no-referrer"
-    media="(prefers-color-scheme: light)"
-  />
-  <link
-    id="theme-dark"
-    rel="stylesheet"
-    href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.8/darkly/bootstrap.min.css"
-    integrity="sha512-+uC0Ar9AG4/j/iF0Ug22TO9D17MAbD94K7J8h17EzXzN3D5kcOpYQdF4OuiLraHSibCVhz4DIcqwsDboRMVStg=="
-    crossorigin="anonymous"
-    referrerpolicy="no-referrer"
-    media="(prefers-color-scheme: dark)"
-  />
+  <link id="theme-light" rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.8/flatly/bootstrap.min.css" integrity="sha512-6cPfXE7P+s3gLoNVw8XfKNI3nc0kKcDIhZzlFp81ZLRcueIq2ayKiHcT9YT7Z+q0+61MKhvVaSaV5PmG7jEsKA==" crossorigin="anonymous" referrerpolicy="no-referrer" media="(prefers-color-scheme: light)" />
+  <link id="theme-dark" rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.8/darkly/bootstrap.min.css" integrity="sha512-+uC0Ar9AG4/j/iF0Ug22TO9D17MAbD94K7J8h17EzXzN3D5kcOpYQdF4OuiLraHSibCVhz4DIcqwsDboRMVStg==" crossorigin="anonymous" referrerpolicy="no-referrer" media="(prefers-color-scheme: dark)" />
   <script src="theme-switch.js"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css" integrity="sha512-2SwdPD6INVrV/lHTZbO2nodKhrnDdJK9/kg2XD1r9uGqPo1cUbujc+IYdlYdEErWNu69gVcYgdxlmVmzTWnetw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <script type="text/javascript">

--- a/src/Dashboard/wwwroot/theme-switch.js
+++ b/src/Dashboard/wwwroot/theme-switch.js
@@ -1,7 +1,7 @@
 'use strict';
 
-(function () {
-  // theme setter with optional persistence (default true)
+(() => {
+  // Theme setter with optional persistence (default true)
   window._setBenchmarkTheme = function (theme, persist) {
     if (persist === undefined) {
       persist = true;
@@ -15,8 +15,9 @@
       light: document.getElementById('theme-light'),
     };
 
-    const activeTheme = theme === 'dark' ? themeLinks.dark : themeLinks.light;
-    const inactiveTheme = theme === 'dark' ? themeLinks.light : themeLinks.dark;
+    const isDark = theme === 'dark';
+    const activeTheme = isDark ? themeLinks.dark : themeLinks.light;
+    const inactiveTheme = isDark ? themeLinks.light : themeLinks.dark;
 
     activeTheme.setAttribute('media', 'all');
     inactiveTheme.setAttribute('media', 'not all');
@@ -24,6 +25,9 @@
     document.documentElement.setAttribute('data-bs-theme', theme);
 
     // Helper to update the toggle icon
+    let depth = 0;
+    const maxDepth = 32;
+
     const updateIcon = () => {
       const toUpdate = document.querySelector('#toggle-theme span');
       const darkIcon = 'fa-moon';
@@ -31,12 +35,12 @@
       if (toUpdate) {
         toUpdate.classList.remove(darkIcon);
         toUpdate.classList.remove(lightIcon);
-        toUpdate.classList.add(theme === 'dark' ? lightIcon : darkIcon);
-      } else {
+        toUpdate.classList.add(isDark ? lightIcon : darkIcon);
+      } else if (depth++ < maxDepth) {
         // During page load, the icon may not be present yet
         requestAnimationFrame(updateIcon);
       }
-    }
+    };
 
     updateIcon();
   };


### PR DESCRIPTION
Follow-ups for #420.

- Fix incorrect control style on the `/token` page in dark mode.
- Add limit to recursive calls.
- Replace `function` with arrow functions.
- Remove redundant variable.
- Sort property assignments.
- Fix use of `"` instead of `'` for consistency.
- Re-theme `yaxis2.color` if set.
- Cache theme into variable.
- Collapse Bootswatch stylesheets down to one line.
