### PR TITLE
Avoid GitHub API rate limiting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,30 @@ jobs:
         path: ./artifacts/publish/Dashboard/release/wwwroot
         if-no-files-found: error
 
+    - name: Publish screenshots
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      if: ${{ !cancelled() }}
+      with:
+        name: screenshots-${{ matrix.os-name }}
+        path: ./artifacts/screenshots/*
+        if-no-files-found: ignore
+
+    - name: Publish traces
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      if: ${{ !cancelled() }}
+      with:
+        name: traces-${{ matrix.os-name }}
+        path: ./artifacts/traces/*
+        if-no-files-found: ignore
+
+    - name: Publish videos
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      if: ${{ !cancelled() }}
+      with:
+        name: videos-${{ matrix.os-name }}
+        path: ./artifacts/videos/*
+        if-no-files-found: ignore
+
   deploy:
     needs: [ build ]
     runs-on: ubuntu-latest

--- a/src/Dashboard/GitHubClient.cs
+++ b/src/Dashboard/GitHubClient.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json.Serialization.Metadata;
@@ -122,7 +121,7 @@ public sealed class GitHubClient(
 
         using var response = await client.SendAsync(message, cancellationToken);
 
-        if (response.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.TooManyRequests)
+        if (response.StatusCode is System.Net.HttpStatusCode.NotFound)
         {
             return null;
         }

--- a/src/Dashboard/GitHubClient.cs
+++ b/src/Dashboard/GitHubClient.cs
@@ -94,7 +94,14 @@ public sealed class GitHubClient(
     {
         var current = options.Value;
         var fileName = current.BenchmarkFileName;
-        var useApi = current.IsGitHubEnterprise || !isPublic;
+
+        // Try to always use the GitHub API to avoid hitting GitHub's rate limits.
+        // See https://github.blog/changelog/2025-05-08-updated-rate-limits-for-unauthenticated-requests/
+        var useApi =
+            current.IsGitHubEnterprise ||
+            !isPublic ||
+            !string.IsNullOrEmpty(await tokenStore.GetTokenAsync(cancellationToken));
+
         var baseAddress = useApi ? current.GitHubApiUrl : current.GitHubDataUrl;
 
         var relativeUri =
@@ -106,11 +113,12 @@ public sealed class GitHubClient(
 
         using var message = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
-        // Always authenticate even without using the GitHub API to avoid hitting GitHub's rate limits.
-        // See https://github.blog/changelog/2025-05-08-updated-rate-limits-for-unauthenticated-requests/
-        await SetHeadersAsync(message.Headers, cancellationToken);
-        message.Headers.Accept.Clear();
-        message.Headers.Add("Accept", "application/vnd.github.v3.raw");
+        if (useApi)
+        {
+            await SetHeadersAsync(message.Headers, cancellationToken);
+            message.Headers.Accept.Clear();
+            message.Headers.Add("Accept", "application/vnd.github.v3.raw");
+        }
 
         using var response = await client.SendAsync(message, cancellationToken);
 

--- a/src/Dashboard/GitHubClient.cs
+++ b/src/Dashboard/GitHubClient.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Martin Costello, 2024. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json.Serialization.Metadata;
@@ -105,16 +106,15 @@ public sealed class GitHubClient(
 
         using var message = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
-        if (useApi)
-        {
-            await SetHeadersAsync(message.Headers, cancellationToken);
-            message.Headers.Accept.Clear();
-            message.Headers.Add("Accept", "application/vnd.github.v3.raw");
-        }
+        // Always authenticate even without using the GitHub API to avoid hitting GitHub's rate limits.
+        // See https://github.blog/changelog/2025-05-08-updated-rate-limits-for-unauthenticated-requests/
+        await SetHeadersAsync(message.Headers, cancellationToken);
+        message.Headers.Accept.Clear();
+        message.Headers.Add("Accept", "application/vnd.github.v3.raw");
 
         using var response = await client.SendAsync(message, cancellationToken);
 
-        if (response.StatusCode is System.Net.HttpStatusCode.NotFound)
+        if (response.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.TooManyRequests)
         {
             return null;
         }

--- a/tests/Dashboard.Tests/DashboardTests.cs
+++ b/tests/Dashboard.Tests/DashboardTests.cs
@@ -254,6 +254,7 @@ public class DashboardTests(
         TaskCompletionSource<string> authorized)
     {
         const string GitHubApi = "https://api.github.com";
+        const string GitHubData = "https://raw.githubusercontent.com";
         const string GitHubLogin = "https://github.com/login/device";
         const string GitHubToken = "https://api.martincostello.com/github";
         const string Owner = "martincostello";
@@ -298,13 +299,22 @@ public class DashboardTests(
 
             foreach (var branch in branches)
             {
-                await page.RouteAsync($"{GitHubApi}/repos/{Owner}/benchmarks/contents/{repo}/data.json?ref={branch}", async (route) =>
+                var dataUrls = new[]
                 {
-                    await route.FulfillAsync(new()
+                    $"{GitHubApi}/repos/{Owner}/benchmarks/contents/{repo}/data.json?ref={branch}",
+                    $"{GitHubData}/{Owner}/benchmarks/{branch}/{repo}/data.json",
+                };
+
+                foreach (var url in dataUrls)
+                {
+                    await page.RouteAsync(url, async (route) =>
                     {
-                        Path = JsonResponseFile($"{repo}-{branch}"),
+                        await route.FulfillAsync(new()
+                        {
+                            Path = JsonResponseFile($"{repo}-{branch}"),
+                        });
                     });
-                });
+                }
             }
         }
 

--- a/tests/Dashboard.Tests/DashboardTests.cs
+++ b/tests/Dashboard.Tests/DashboardTests.cs
@@ -254,7 +254,6 @@ public class DashboardTests(
         TaskCompletionSource<string> authorized)
     {
         const string GitHubApi = "https://api.github.com";
-        const string GitHubData = "https://raw.githubusercontent.com";
         const string GitHubLogin = "https://github.com/login/device";
         const string GitHubToken = "https://api.martincostello.com/github";
         const string Owner = "martincostello";
@@ -299,7 +298,7 @@ public class DashboardTests(
 
             foreach (var branch in branches)
             {
-                await page.RouteAsync($"{GitHubData}/{Owner}/benchmarks/{branch}/{repo}/data.json", async (route) =>
+                await page.RouteAsync($"{GitHubApi}/repos/{Owner}/benchmarks/contents/{repo}/data.json?ref={branch}", async (route) =>
                 {
                     await route.FulfillAsync(new()
                     {

--- a/tests/Dashboard.Tests/GitHubClientTests.cs
+++ b/tests/Dashboard.Tests/GitHubClientTests.cs
@@ -104,7 +104,7 @@ public class GitHubClientTests
     }
 
     [Fact]
-    public async Task Can_Get_Benchmarks_Public_GitHub_Repository()
+    public async Task Can_Get_Benchmarks_Public_GitHub_Repository_When_No_Token()
     {
         // Arrange
         Options.GitHubApiUrl = new("https://api.github.com");
@@ -112,6 +112,42 @@ public class GitHubClientTests
         var builder = new HttpRequestInterceptionBuilder()
             .ForGet()
             .ForUrl("https://raw.githubusercontent.local/octocat/benchmarks/my-branch/my-repository/data.json")
+            .WithJsonContent(
+                new
+                {
+                    lastUpdated = 1725355699000,
+                    repoUrl = "https://github.local/octocat/my-repository",
+                });
+
+        builder.RegisterWith(Interceptor);
+
+        string repository = "my-repository";
+        string branch = "my-branch";
+        bool isPublic = true;
+
+        // Act
+        var actual = await Target.GetBenchmarksAsync(repository, branch, isPublic, TestContext.Current.CancellationToken);
+
+        // Assert
+        actual.ShouldNotBeNull();
+        actual.LastUpdated.ShouldBe(new(2024, 09, 03, 09, 28, 19, TimeSpan.Zero));
+        actual.RepositoryUrl.ShouldBe("https://github.local/octocat/my-repository");
+    }
+
+    [Fact]
+    public async Task Can_Get_Benchmarks_Public_GitHub_Repository_With_Token()
+    {
+        // Arrange
+        await TokenStore.StoreTokenAsync("foo", TestContext.Current.CancellationToken);
+
+        Options.GitHubApiUrl = new("https://api.github.com");
+
+        var builder = new HttpRequestInterceptionBuilder()
+            .ForGet()
+            .ForUrl("https://api.github.com/repos/octocat/benchmarks/contents/my-repository/data.json?ref=my-branch")
+            .ForRequestHeader("Accept", "application/vnd.github.v3.raw")
+            .ForRequestHeader("Authorization", "token foo")
+            .ForRequestHeader("X-GitHub-Api-Version", "2026-03-10")
             .WithJsonContent(
                 new
                 {

--- a/tests/Dashboard.Tests/GitHubClientTests.cs
+++ b/tests/Dashboard.Tests/GitHubClientTests.cs
@@ -205,14 +205,16 @@ public class GitHubClientTests
         actual.RepositoryUrl.ShouldBe("https://github.local/octocat/my-repository");
     }
 
-    [Fact]
-    public async Task Can_Get_Benchmarks_Returns_Null_If_Not_Found()
+    [Theory]
+    [InlineData(404)]
+    [InlineData(429)]
+    public async Task Can_Get_Benchmarks_Returns_Null_For_Http_Status(int status)
     {
         // Arrange
         var builder = new HttpRequestInterceptionBuilder()
             .ForGet()
             .ForUrl("https://api.github.local/repos/octocat/benchmarks/contents/my-repository/data.json?ref=my-branch")
-            .WithStatus(404);
+            .WithStatus(status);
 
         builder.RegisterWith(Interceptor);
 
@@ -240,6 +242,7 @@ public class GitHubClientTests
             .ForGet()
             .ForUrl("https://api.github.local/repos/octocat/my-repository")
             .ForRequestHeader("Accept", "application/vnd.github+json")
+            .ForRequestHeader("Authorization", "token foo")
             .ForRequestHeader("X-GitHub-Api-Version", "2026-03-10")
             .WithJsonContent(
                 new
@@ -285,6 +288,7 @@ public class GitHubClientTests
             .ForGet()
             .ForUrl("https://api.github.local/repos/octocat/my-repository/branches")
             .ForRequestHeader("Accept", "application/vnd.github+json")
+            .ForRequestHeader("Authorization", "token foo")
             .ForRequestHeader("X-GitHub-Api-Version", "2026-03-10")
             .WithJsonContent(
                 new[]
@@ -320,6 +324,7 @@ public class GitHubClientTests
             .ForGet()
             .ForUrl("https://github.local/api/v3/user")
             .ForRequestHeader("Accept", "application/vnd.github+json")
+            .ForRequestHeader("Authorization", "token foo")
             .ForRequestHeader("X-GitHub-Api-Version", "2026-03-10")
             .WithJsonContent(
                 new

--- a/tests/Dashboard.Tests/GitHubClientTests.cs
+++ b/tests/Dashboard.Tests/GitHubClientTests.cs
@@ -243,7 +243,6 @@ public class GitHubClientTests
 
     [Theory]
     [InlineData(404)]
-    [InlineData(429)]
     public async Task Can_Get_Benchmarks_Returns_Null_For_Http_Status(int status)
     {
         // Arrange


### PR DESCRIPTION
Avoid getting rate limits for requests to get the raw benchmark data.
