### PR TITLE
Fix build

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,4 +16,13 @@
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <VersionPrefix>1.0.0</VersionPrefix>
   </PropertyGroup>
+  <!-- HACK Workaround for https://github.com/ImageMagick/ImageMagick/discussions/8675 -->
+  <ItemGroup>
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-8vfj-q2cp-5m5j" />
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-98cp-rj9f-6v5g" />
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-pmpg-6pww-fg6q" />
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-q8h3-jv9v-57qx" />
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-w54j-7wpm-crhj" />
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-x928-4434-crqj" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Suppress NuGet Audit warnings for which no patches yet exist.

See https://github.com/ImageMagick/ImageMagick/discussions/8675.
