### PR TITLE
Fix x-axis ordering

### DIFF
--- a/src/Dashboard/Pages/Home.razor.cs
+++ b/src/Dashboard/Pages/Home.razor.cs
@@ -173,7 +173,14 @@ public partial class Home : IAsyncDisposable
 
         foreach ((var suite, var results) in sortedGroups)
         {
-            var items = results.Select((p) => p.Value).ToList();
+            // Order the points by the commit's timestamp rather than when the benchmark
+            // run was published. Benchmark runs can be published out of order (for example,
+            // a slower benchmark for an earlier commit can finish after a later commit's run),
+            // which would otherwise render the commits out of order along the chart's x-axis.
+            var items = results
+                .Select((p) => p.Value)
+                .OrderBy((p) => p.Commit.LastUpdated ?? p.Timestamp)
+                .ToList();
 
             NormalizeUnits(items);
 

--- a/tests/Dashboard.Tests/Pages/HomeTests.cs
+++ b/tests/Dashboard.Tests/Pages/HomeTests.cs
@@ -144,6 +144,56 @@ public class HomeTests : DashboardTestContext
     }
 
     [Fact]
+    public static void GroupBenchmarks_Orders_Items_By_Commit_Timestamp_Not_Run_Timestamp()
+    {
+        // Arrange - the runs are published out of order relative to the commit history.
+        // The newer commit's benchmarks finished (and were published) before the older
+        // commit's slower benchmarks, so the newer commit has the earlier run timestamp.
+        var olderCommit = CreateCommit("older");
+        olderCommit.LastUpdated = new DateTimeOffset(2024, 09, 01, 12, 00, 00, TimeSpan.Zero);
+
+        var newerCommit = CreateCommit("newer");
+        newerCommit.LastUpdated = new DateTimeOffset(2024, 09, 02, 12, 00, 00, TimeSpan.Zero);
+
+        var runs = new List<BenchmarkRun>()
+        {
+            new()
+            {
+                // Newer commit, but its run was published first.
+                Timestamp = new DateTimeOffset(2024, 09, 03, 00, 00, 00, TimeSpan.Zero),
+                Commit = newerCommit,
+                Benchmarks =
+                [
+                    new() { Name = "A", Value = 2 },
+                ],
+            },
+            new()
+            {
+                // Older commit, but its run was published later.
+                Timestamp = new DateTimeOffset(2024, 09, 04, 00, 00, 00, TimeSpan.Zero),
+                Commit = olderCommit,
+                Benchmarks =
+                [
+                    new() { Name = "A", Value = 1 },
+                ],
+            },
+        };
+
+        // Act
+        var actual = Home.GroupBenchmarks(runs);
+
+        // Assert - the points are ordered by the commit timestamp (older first), not the
+        // run timestamp or the order in which the runs were published.
+        var values = actual["A"];
+
+        values.Count.ShouldBe(2);
+        values[0].Commit.Sha.ShouldBe("older");
+        values[0].Result.Value.ShouldBe(1);
+        values[1].Commit.Sha.ShouldBe("newer");
+        values[1].Result.Value.ShouldBe(2);
+    }
+
+    [Fact]
     public static void GroupBenchmarks_Groups_Benchmarks_Correctly_With_Multiple_Benchmarks()
     {
         // Arrange


### PR DESCRIPTION
Order commits by their timestamp so out-of-order data in the JSON is still rendered in the order of commit.
