### PR TITLE
Render environment metadata

### DIFF
--- a/src/Dashboard/Models/BenchmarkItem.cs
+++ b/src/Dashboard/Models/BenchmarkItem.cs
@@ -11,4 +11,5 @@ namespace MartinCostello.Benchmarks.Models;
 public sealed record BenchmarkItem(
     [property: JsonPropertyName("commit")] GitCommit Commit,
     [property: JsonPropertyName("result")] BenchmarkResult Result,
-    [property: JsonPropertyName("timestamp")] DateTimeOffset Timestamp = default);
+    [property: JsonPropertyName("timestamp")] DateTimeOffset Timestamp = default,
+    [property: JsonPropertyName("metadata")] BenchmarkMetadata? Metadata = null);

--- a/src/Dashboard/Models/BenchmarkMetadata.cs
+++ b/src/Dashboard/Models/BenchmarkMetadata.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Martin Costello, 2024. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace MartinCostello.Benchmarks.Models;
+
+/// <summary>
+/// A class representing metadata associated with a benchmark run. This class cannot be inherited.
+/// </summary>
+public sealed class BenchmarkMetadata
+{
+    /// <summary>
+    /// Gets or sets the metadata describing the environment the benchmark run was performed in, if any.
+    /// </summary>
+    [JsonPropertyName("environment")]
+    public IDictionary<string, JsonElement>? Environment { get; set; }
+}

--- a/src/Dashboard/Models/BenchmarkRun.cs
+++ b/src/Dashboard/Models/BenchmarkRun.cs
@@ -24,6 +24,12 @@ public sealed class BenchmarkRun
     public DateTimeOffset Timestamp { get; set; }
 
     /// <summary>
+    /// Gets or sets the metadata associated with the run, if any.
+    /// </summary>
+    [JsonPropertyName("metadata")]
+    public BenchmarkMetadata? Metadata { get; set; }
+
+    /// <summary>
     /// Gets or sets benchmark results for the run.
     /// </summary>
     [JsonPropertyName("benches")]

--- a/src/Dashboard/Pages/Home.razor.cs
+++ b/src/Dashboard/Pages/Home.razor.cs
@@ -164,7 +164,7 @@ public partial class Home : IAsyncDisposable
 
                 if (!results.ContainsKey(timestamp))
                 {
-                    results.Add(timestamp, new(run.Commit, benchmark, run.Timestamp));
+                    results.Add(timestamp, new(run.Commit, benchmark, run.Timestamp, run.Metadata));
                 }
             }
         }

--- a/src/Dashboard/wwwroot/app.js
+++ b/src/Dashboard/wwwroot/app.js
@@ -168,12 +168,15 @@ function createDashboardApp(dependencies = {}) {
             return undefined;
         }
 
-        const summary =
-            keys.length === 1
-                ? formatMetadataFieldValue(environment[keys[0]])
-                : keys.map((key) => `${formatMetadataFieldLabel(key)}: ${formatMetadataFieldValue(environment[key])}`).join(' · ');
+        const items = keys.map((key) => {
+            const label = formatMetadataFieldLabel(key);
+            const value = formatMetadataFieldValue(environment[key]);
+            const text = keys.length === 1 && label === group.label ? value : `${label}: ${value}`;
 
-        return `<b>${htmlEncode(group.label)}:</b> ${summary}`;
+            return `- ${text}`;
+        });
+
+        return [`<b>${htmlEncode(group.label)}</b>`, ...items].join(newline);
     };
 
     const formatEnvironmentMetadata = (environment) => {
@@ -182,22 +185,22 @@ function createDashboardApp(dependencies = {}) {
         }
 
         const ungroupedKeys = new Set(Object.keys(environment));
-        const lines = [];
+        const blocks = [];
 
         for (const group of environmentMetadataGroups) {
-            const line = formatMetadataGroup(group, environment);
+            const block = formatMetadataGroup(group, environment);
 
-            if (line !== undefined) {
+            if (block !== undefined) {
                 group.keys.forEach((key) => ungroupedKeys.delete(key));
-                lines.push(line);
+                blocks.push(block);
             }
         }
 
         for (const key of ungroupedKeys) {
-            lines.push(`<b>${htmlEncode(formatMetadataFieldLabel(key))}:</b> ${formatMetadataFieldValue(environment[key])}`);
+            blocks.push(formatMetadataGroup({ label: formatMetadataFieldLabel(key), keys: [key] }, environment));
         }
 
-        return lines;
+        return blocks;
     };
 
     const createCustomData = (dataset) =>
@@ -212,12 +215,7 @@ function createDashboardApp(dependencies = {}) {
             const timestamp = normalizeHtml(item.commit.timestamp);
             const author = normalizeHtml(item.commit.author.username);
 
-            const blocks = [message, `${timestamp} authored by @${author}`];
-            const environmentLines = formatEnvironmentMetadata(item.metadata?.environment);
-
-            if (environmentLines.length > 0) {
-                blocks.push(environmentLines.join(newline));
-            }
+            const blocks = [message, `${timestamp} authored by @${author}`, ...formatEnvironmentMetadata(item.metadata?.environment)];
 
             return blocks.join(newline + newline) + newline;
         });

--- a/src/Dashboard/wwwroot/app.js
+++ b/src/Dashboard/wwwroot/app.js
@@ -136,6 +136,70 @@ function createDashboardApp(dependencies = {}) {
         return label;
     };
 
+    const environmentMetadataFieldLabels = Object.freeze({
+        Architecture: 'Architecture',
+        BenchmarkDotNetVersion: 'BenchmarkDotNet',
+        DotNetCliVersion: '.NET SDK',
+        LogicalCoreCount: 'Logical cores',
+        OsVersion: 'OS',
+        PhysicalCoreCount: 'Physical cores',
+        PhysicalProcessorCount: 'Processors',
+        ProcessorName: 'Processor',
+        RuntimeVersion: 'Runtime',
+    });
+
+    const environmentMetadataGroups = Object.freeze([
+        Object.freeze({ label: '.NET Versions', keys: Object.freeze(['RuntimeVersion', 'DotNetCliVersion', 'BenchmarkDotNetVersion']) }),
+        Object.freeze({
+            label: 'Processor',
+            keys: Object.freeze(['ProcessorName', 'Architecture', 'PhysicalProcessorCount', 'PhysicalCoreCount', 'LogicalCoreCount']),
+        }),
+        Object.freeze({ label: 'OS', keys: Object.freeze(['OsVersion']) }),
+    ]);
+
+    const humanizeMetadataKey = (key) => key.replaceAll(/([a-z0-9])([A-Z])/g, '$1 $2');
+    const formatMetadataFieldLabel = (key) => environmentMetadataFieldLabels[key] ?? humanizeMetadataKey(key);
+    const formatMetadataFieldValue = (value) => (typeof value === 'string' ? normalizeHtml(value) : String(value));
+
+    const formatMetadataGroup = (group, environment) => {
+        const keys = group.keys.filter((key) => key in environment);
+
+        if (keys.length === 0) {
+            return undefined;
+        }
+
+        const summary =
+            keys.length === 1
+                ? formatMetadataFieldValue(environment[keys[0]])
+                : keys.map((key) => `${formatMetadataFieldLabel(key)}: ${formatMetadataFieldValue(environment[key])}`).join(' · ');
+
+        return `<b>${htmlEncode(group.label)}:</b> ${summary}`;
+    };
+
+    const formatEnvironmentMetadata = (environment) => {
+        if (!environment || typeof environment !== 'object') {
+            return [];
+        }
+
+        const ungroupedKeys = new Set(Object.keys(environment));
+        const lines = [];
+
+        for (const group of environmentMetadataGroups) {
+            const line = formatMetadataGroup(group, environment);
+
+            if (line !== undefined) {
+                group.keys.forEach((key) => ungroupedKeys.delete(key));
+                lines.push(line);
+            }
+        }
+
+        for (const key of ungroupedKeys) {
+            lines.push(`<b>${htmlEncode(formatMetadataFieldLabel(key))}:</b> ${formatMetadataFieldValue(environment[key])}`);
+        }
+
+        return lines;
+    };
+
     const createCustomData = (dataset) =>
         dataset.map((item) => {
             const message = item.commit.message
@@ -148,7 +212,14 @@ function createDashboardApp(dependencies = {}) {
             const timestamp = normalizeHtml(item.commit.timestamp);
             const author = normalizeHtml(item.commit.author.username);
 
-            return message + newline + newline + `${timestamp} authored by @${author}` + newline;
+            const blocks = [message, `${timestamp} authored by @${author}`];
+            const environmentLines = formatEnvironmentMetadata(item.metadata?.environment);
+
+            if (environmentLines.length > 0) {
+                blocks.push(environmentLines.join(newline));
+            }
+
+            return blocks.join(newline + newline) + newline;
         });
 
     const createHoverTemplate = () =>
@@ -748,6 +819,7 @@ function createDashboardApp(dependencies = {}) {
         createDeepLinkUrl,
         createJsonDataUrl,
         formatDateValue,
+        formatEnvironmentMetadata,
         getThemeStyles,
         getSelectedDateRange,
         isValidDateRange,

--- a/tests/Dashboard.Tests/Pages/HomeTests.cs
+++ b/tests/Dashboard.Tests/Pages/HomeTests.cs
@@ -796,6 +796,44 @@ public class HomeTests : DashboardTestContext
     }
 
     [Fact]
+    public void GroupBenchmarks_Copies_Environment_Metadata_From_The_Run()
+    {
+        // Arrange
+        var metadata = new BenchmarkMetadata()
+        {
+            Environment = new Dictionary<string, JsonElement>()
+            {
+                ["ProcessorName"] = JsonSerializer.SerializeToElement("AMD Ryzen 9 5950X"),
+                ["LogicalCoreCount"] = JsonSerializer.SerializeToElement(32),
+            },
+        };
+
+        var runWithMetadata = new BenchmarkRun()
+        {
+            Timestamp = new DateTimeOffset(2024, 09, 03, 12, 00, 00, TimeSpan.Zero),
+            Commit = CreateCommit("with-metadata"),
+            Metadata = metadata,
+            Benchmarks = [new() { Name = "A", Value = 1 }],
+        };
+
+        var runWithoutMetadata = new BenchmarkRun()
+        {
+            Timestamp = new DateTimeOffset(2024, 09, 04, 12, 00, 00, TimeSpan.Zero),
+            Commit = CreateCommit("without-metadata"),
+            Benchmarks = [new() { Name = "A", Value = 2 }],
+        };
+
+        // Act
+        var grouped = Home.GroupBenchmarks([runWithMetadata, runWithoutMetadata]);
+
+        // Assert
+        var items = grouped["A"];
+
+        items[0].Metadata.ShouldBe(metadata);
+        items[1].Metadata.ShouldBeNull();
+    }
+
+    [Fact]
     public void NormalizeUnits_Scales_From_Nanoseconds_To_Microseconds_And_Updates_Range()
     {
         // Arrange

--- a/tests/Dashboard.Vitest/app.test.js
+++ b/tests/Dashboard.Vitest/app.test.js
@@ -341,11 +341,22 @@ describe('DashboardApp', () => {
 
         const hover = definition.data[0].customdata[0];
 
-        expect(hover).toContain('<b>.NET Versions:</b> Runtime: .NET 8.0.8 (8.0.824.36612) · .NET SDK: 8.0.401 · BenchmarkDotNet: 0.14.0');
         expect(hover).toContain(
-            '<b>Processor:</b> Processor: 12th Gen Intel Core i7-1270P · Architecture: X64 · Processors: 1 · Physical cores: 12 · Logical cores: 16'
+            ['<b>.NET Versions</b>', '- Runtime: .NET 8.0.8 (8.0.824.36612)', '- .NET SDK: 8.0.401', '- BenchmarkDotNet: 0.14.0'].join(
+                '<br>'
+            )
         );
-        expect(hover).toContain('<b>OS:</b> Windows 11 (10.0.22621.4037/22H2/2022Update/SunValley2)');
+        expect(hover).toContain(
+            [
+                '<b>Processor</b>',
+                '- Processor: 12th Gen Intel Core i7-1270P',
+                '- Architecture: X64',
+                '- Processors: 1',
+                '- Physical cores: 12',
+                '- Logical cores: 16',
+            ].join('<br>')
+        );
+        expect(hover).toContain(['<b>OS</b>', '- Windows 11 (10.0.22621.4037/22H2/2022Update/SunValley2)'].join('<br>'));
     });
 
     it('omits the environment metadata section from hovercards when absent', () => {
@@ -382,7 +393,7 @@ describe('DashboardApp', () => {
 
         const lines = app.formatEnvironmentMetadata({ CustomToolingVersion: '1.2.3' });
 
-        expect(lines).toEqual(['<b>Custom Tooling Version:</b> 1.2.3']);
+        expect(lines).toEqual(['<b>Custom Tooling Version</b><br>- 1.2.3']);
     });
 
     it('HTML-encodes the chart anchor id in chart definitions', () => {

--- a/tests/Dashboard.Vitest/app.test.js
+++ b/tests/Dashboard.Vitest/app.test.js
@@ -297,6 +297,94 @@ describe('DashboardApp', () => {
         expect(definition.data[0].customdata[0]).not.toContain('&quot;');
     });
 
+    it('groups environment metadata into hovercards when present', () => {
+        document.documentElement.style.setProperty('--bs-body-color', '#123456');
+        document.documentElement.style.setProperty('--bs-body-bg', '#abcdef');
+        document.documentElement.style.setProperty('--plot-hover-color', '#111111');
+        document.documentElement.style.setProperty('--plot-hover-background-color', '#222222');
+        document.documentElement.style.setProperty('--bs-font-sans-serif', 'Inter');
+
+        document.body.innerHTML = '<div id="suite-name"><div id="chart"></div></div>';
+
+        Object.defineProperty(document.documentElement, 'clientWidth', {
+            configurable: true,
+            value: 1280,
+        });
+
+        const app = window.DashboardApp.createDashboardApp(createDependencies());
+        const definition = app.createChartDefinition('chart', {
+            colors: {
+                memory: '#e34c26',
+                time: '#178600',
+            },
+            dataset: [
+                createBenchmarkItem({
+                    metadata: {
+                        environment: {
+                            Architecture: 'X64',
+                            BenchmarkDotNetVersion: '0.14.0',
+                            DotNetCliVersion: '8.0.401',
+                            LogicalCoreCount: 16,
+                            OsVersion: 'Windows 11 (10.0.22621.4037/22H2/2022Update/SunValley2)',
+                            PhysicalCoreCount: 12,
+                            PhysicalProcessorCount: 1,
+                            ProcessorName: '12th Gen Intel Core i7-1270P',
+                            RuntimeVersion: '.NET 8.0.8 (8.0.824.36612)',
+                        },
+                    },
+                }),
+            ],
+            errorBars: false,
+            imageFormat: 'png',
+            name: 'My Benchmark',
+        });
+
+        const hover = definition.data[0].customdata[0];
+
+        expect(hover).toContain('<b>.NET Versions:</b> Runtime: .NET 8.0.8 (8.0.824.36612) · .NET SDK: 8.0.401 · BenchmarkDotNet: 0.14.0');
+        expect(hover).toContain(
+            '<b>Processor:</b> Processor: 12th Gen Intel Core i7-1270P · Architecture: X64 · Processors: 1 · Physical cores: 12 · Logical cores: 16'
+        );
+        expect(hover).toContain('<b>OS:</b> Windows 11 (10.0.22621.4037/22H2/2022Update/SunValley2)');
+    });
+
+    it('omits the environment metadata section from hovercards when absent', () => {
+        document.documentElement.style.setProperty('--bs-body-color', '#123456');
+        document.documentElement.style.setProperty('--bs-body-bg', '#abcdef');
+        document.documentElement.style.setProperty('--plot-hover-color', '#111111');
+        document.documentElement.style.setProperty('--plot-hover-background-color', '#222222');
+        document.documentElement.style.setProperty('--bs-font-sans-serif', 'Inter');
+
+        document.body.innerHTML = '<div id="suite-name"><div id="chart"></div></div>';
+
+        Object.defineProperty(document.documentElement, 'clientWidth', {
+            configurable: true,
+            value: 1280,
+        });
+
+        const app = window.DashboardApp.createDashboardApp(createDependencies());
+        const definition = app.createChartDefinition('chart', {
+            colors: {
+                memory: '#e34c26',
+                time: '#178600',
+            },
+            dataset: [createBenchmarkItem()],
+            errorBars: false,
+            imageFormat: 'png',
+            name: 'My Benchmark',
+        });
+
+        expect(definition.data[0].customdata[0]).not.toContain('<b>');
+    });
+
+    it('formats an unrecognized environment metadata key using a humanized label', () => {
+        const app = window.DashboardApp.createDashboardApp(createDependencies());
+
+        const lines = app.formatEnvironmentMetadata({ CustomToolingVersion: '1.2.3' });
+
+        expect(lines).toEqual(['<b>Custom Tooling Version:</b> 1.2.3']);
+    });
+
     it('HTML-encodes the chart anchor id in chart definitions', () => {
         document.documentElement.style.setProperty('--bs-body-color', '#123456');
         document.documentElement.style.setProperty('--bs-body-bg', '#abcdef');


### PR DESCRIPTION
Consume the changes from https://github.com/martincostello/benchmarkdotnet-results-publisher/pull/965 to render environment metadata in the hovercards, when available.

<img width="570" height="577" alt="image" src="https://github.com/user-attachments/assets/47cac1b1-0487-473a-91df-3d34fdefda26" />
