### PR TITLE
Fix hovercards with metadata

### DIFF
--- a/src/Dashboard/wwwroot/app.js
+++ b/src/Dashboard/wwwroot/app.js
@@ -136,68 +136,24 @@ function createDashboardApp(dependencies = {}) {
         return label;
     };
 
-    const environmentMetadataFieldLabels = Object.freeze({
-        Architecture: 'Architecture',
-        BenchmarkDotNetVersion: 'BenchmarkDotNet',
-        DotNetCliVersion: '.NET SDK',
-        LogicalCoreCount: 'Logical cores',
-        OsVersion: 'OS',
-        PhysicalCoreCount: 'Physical cores',
-        PhysicalProcessorCount: 'Processors',
-        ProcessorName: 'Processor',
-        RuntimeVersion: 'Runtime',
-    });
-
-    const environmentMetadataGroups = Object.freeze([
-        Object.freeze({ label: '.NET Versions', keys: Object.freeze(['RuntimeVersion', 'DotNetCliVersion', 'BenchmarkDotNetVersion']) }),
-        Object.freeze({
-            label: 'Processor',
-            keys: Object.freeze(['ProcessorName', 'Architecture', 'PhysicalProcessorCount', 'PhysicalCoreCount', 'LogicalCoreCount']),
-        }),
-        Object.freeze({ label: 'OS', keys: Object.freeze(['OsVersion']) }),
-    ]);
-
-    const humanizeMetadataKey = (key) => key.replaceAll(/([a-z0-9])([A-Z])/g, '$1 $2');
-    const formatMetadataFieldLabel = (key) => environmentMetadataFieldLabels[key] ?? humanizeMetadataKey(key);
     const formatMetadataFieldValue = (value) => (typeof value === 'string' ? normalizeHtml(value) : String(value));
-
-    const formatMetadataGroup = (group, environment) => {
-        const keys = group.keys.filter((key) => key in environment);
-
-        if (keys.length === 0) {
-            return undefined;
-        }
-
-        const items = keys.map((key) => {
-            const label = formatMetadataFieldLabel(key);
-            const value = formatMetadataFieldValue(environment[key]);
-            const text = keys.length === 1 && label === group.label ? value : `${label}: ${value}`;
-
-            return `- ${text}`;
-        });
-
-        return [`<b>${htmlEncode(group.label)}</b>`, ...items].join(newline);
-    };
 
     const formatEnvironmentMetadata = (environment) => {
         if (!environment || typeof environment !== 'object') {
             return [];
         }
 
-        const ungroupedKeys = new Set(Object.keys(environment));
         const blocks = [];
 
-        for (const group of environmentMetadataGroups) {
-            const block = formatMetadataGroup(group, environment);
+        if (environment.ProcessorName) {
+            const processor = formatMetadataFieldValue(environment.ProcessorName);
+            const architecture = environment.Architecture ? ` (${formatMetadataFieldValue(environment.Architecture)})` : '';
 
-            if (block !== undefined) {
-                group.keys.forEach((key) => ungroupedKeys.delete(key));
-                blocks.push(block);
-            }
+            blocks.push(`Processor: ${processor}${architecture}`);
         }
 
-        for (const key of ungroupedKeys) {
-            blocks.push(formatMetadataGroup({ label: formatMetadataFieldLabel(key), keys: [key] }, environment));
+        if (environment.OsVersion) {
+            blocks.push(`OS: ${formatMetadataFieldValue(environment.OsVersion)}`);
         }
 
         return blocks;
@@ -215,7 +171,12 @@ function createDashboardApp(dependencies = {}) {
             const timestamp = normalizeHtml(item.commit.timestamp);
             const author = normalizeHtml(item.commit.author.username);
 
-            const blocks = [message, `${timestamp} authored by @${author}`, ...formatEnvironmentMetadata(item.metadata?.environment)];
+            const metadataLines = formatEnvironmentMetadata(item.metadata?.environment);
+            const blocks = [message, `${timestamp} authored by @${author}`];
+
+            if (metadataLines.length > 0) {
+                blocks.push(metadataLines.join(newline));
+            }
 
             return blocks.join(newline + newline) + newline;
         });

--- a/tests/Dashboard.Vitest/app.test.js
+++ b/tests/Dashboard.Vitest/app.test.js
@@ -342,21 +342,12 @@ describe('DashboardApp', () => {
         const hover = definition.data[0].customdata[0];
 
         expect(hover).toContain(
-            ['<b>.NET Versions</b>', '- Runtime: .NET 8.0.8 (8.0.824.36612)', '- .NET SDK: 8.0.401', '- BenchmarkDotNet: 0.14.0'].join(
-                '<br>'
-            )
+            'Processor: 12th Gen Intel Core i7-1270P (X64)<br>OS: Windows 11 (10.0.22621.4037/22H2/2022Update/SunValley2)'
         );
-        expect(hover).toContain(
-            [
-                '<b>Processor</b>',
-                '- Processor: 12th Gen Intel Core i7-1270P',
-                '- Architecture: X64',
-                '- Processors: 1',
-                '- Physical cores: 12',
-                '- Logical cores: 16',
-            ].join('<br>')
-        );
-        expect(hover).toContain(['<b>OS</b>', '- Windows 11 (10.0.22621.4037/22H2/2022Update/SunValley2)'].join('<br>'));
+
+        const messageEnd = hover.indexOf('authored by');
+        expect(hover.indexOf('Processor:')).toBeGreaterThan(messageEnd);
+        expect(hover.indexOf('OS:')).toBeGreaterThan(hover.indexOf('Processor:'));
     });
 
     it('omits the environment metadata section from hovercards when absent', () => {
@@ -385,15 +376,24 @@ describe('DashboardApp', () => {
             name: 'My Benchmark',
         });
 
-        expect(definition.data[0].customdata[0]).not.toContain('<b>');
+        expect(definition.data[0].customdata[0]).not.toContain('Processor:');
+        expect(definition.data[0].customdata[0]).not.toContain('OS:');
     });
 
-    it('formats an unrecognized environment metadata key using a humanized label', () => {
+    it('renders only the Processor field when the architecture is not present', () => {
+        const app = window.DashboardApp.createDashboardApp(createDependencies());
+
+        const lines = app.formatEnvironmentMetadata({ ProcessorName: 'AMD EPYC 7763' });
+
+        expect(lines).toEqual(['Processor: AMD EPYC 7763']);
+    });
+
+    it('ignores unrecognized environment metadata keys', () => {
         const app = window.DashboardApp.createDashboardApp(createDependencies());
 
         const lines = app.formatEnvironmentMetadata({ CustomToolingVersion: '1.2.3' });
 
-        expect(lines).toEqual(['<b>Custom Tooling Version</b><br>- 1.2.3']);
+        expect(lines).toEqual([]);
     });
 
     it('HTML-encodes the chart anchor id in chart definitions', () => {


### PR DESCRIPTION
Fix hovercards not rendering due to the metadata making them too long. Instead, just show the processor and OS information on a single line each.
